### PR TITLE
refactor: Login button fixed landing page

### DIFF
--- a/app/components/sign-in.tsx
+++ b/app/components/sign-in.tsx
@@ -1,7 +1,7 @@
 
 import { signIn } from "@/app/auth"
  
-export function SignIn() {
+export function SignIn({displayText} : {displayText : string}) {
   return (
     <form
       action={async () => {
@@ -9,7 +9,7 @@ export function SignIn() {
         await signIn("google")
       }}
     >
-      <button type="submit">Signin with Google</button>
+      <button type="submit" title="Login with Google" className="bg-[#00B0FF] text-white py-2 px-4 rounded hover:bg-[#007BFF] sm:py-3 sm:px-6">{displayText}</button>
     </form>
   )
 } 

--- a/app/landing_page/landing_header.tsx
+++ b/app/landing_page/landing_header.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { SignIn } from '../components/sign-in';
 
 function Header() {
   return (
@@ -6,9 +7,7 @@ function Header() {
       <div className="container max-w-xl mx-auto px-4 sm:px-8">
         <h1 className="text-4xl mb-2 text-[#0070f3] sm:text-5xl">Cramming,<br className="sm:hidden" /> Made Easy.</h1>
         <p className="text-lg mb-4 sm:text-xl">Presenting ExamCooker, your one-stop solution to cram before exams</p>
-        <button className="bg-[#00B0FF] text-white py-2 px-4 rounded hover:bg-[#007BFF] sm:py-3 sm:px-6">
-          Login
-        </button>
+          <SignIn displayText='Login'/>
       </div>
     </header>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -58,7 +58,6 @@ export default async function Home() {
                     <Features />
                     <div className="flex flex-col items-center py-12">
                         <span className="text-3xl font-semibold mb-4">Start Cooking Your Academic Success Today</span>
-                        <SignIn />
                     </div>
                     <Footer />
                 </div>


### PR DESCRIPTION
Sign in with Google action moved into Login button, previous 'sign in with google' button no longer present.

![image](https://github.com/ACM-VIT/ExamCooker-2024/assets/148008559/230cb49b-a7eb-4bd9-80fd-c38763fe3fc0)

on interaction, leads here:
![image](https://github.com/ACM-VIT/ExamCooker-2024/assets/148008559/1c9785d0-73c7-404a-a8f9-7c00d9d248f4)
