### PR TITLE
fix: Navbar Appearing too small on smaller screen sizes

### DIFF
--- a/app/components/NavBar.tsx
+++ b/app/components/NavBar.tsx
@@ -44,7 +44,7 @@ const NavBar: React.FC<{ isNavOn: boolean; toggleNavbar: () => void }> = ({
             {loading && <Loading />} 
             <nav
                 className={`fixed top-0 left-0 z-50 flex flex-col justify-between items-center h-screen ${
-                    isNavOn ? "bg-[#5fc4e7] dark:bg-[#232530] dark:border-[#3BF4C7] dark:border w-[3vw]" : ""
+                    isNavOn ? "bg-[#5fc4e7] dark:bg-[#232530] dark:border-[#3BF4C7] dark:border w-[50px]" : ""
                 } text-white p-1 transition-all duration-300 ease-in-out`}
             >
                 {isNavOn && (


### PR DESCRIPTION
### Same edit as before, changing 3vw to 50px

![Screen Shot 2024-07-08 at 12 26 08](https://github.com/ACM-VIT/ExamCooker-2024/assets/89975500/08af1fb6-c8b8-48f1-b773-24fa21eca375)
