### PR TITLE
feat: Button to copy link of past paper or note

### DIFF
--- a/app/@protected_routes/notes/[id]/page.tsx
+++ b/app/@protected_routes/notes/[id]/page.tsx
@@ -6,6 +6,7 @@ import {TimeHandler} from '@/app/components/forumpost/CommentContainer';
 import {notFound} from "next/navigation";
 import DeleteButton from '@/app/components/DeleteButton';
 import {Metadata} from "next";
+import ShareLink from '@/app/components/ShareLink';
 // import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 // import { faArrowLeft } from '@fortawesome/free-solid-svg-icons';
 
@@ -106,13 +107,14 @@ async function PdfViewerPage({params}: { params: { id: string } }) {
                             <p className="text-base sm:text-lg"><span
                                 className="font-semibold">Posted by: </span> {note.author?.name?.slice(0, -10) || 'Unknown'}
                             </p>
-                            <div className="flex gap-2 items-center">
+                            <div className="flex gap-2 items-center justify-between">
                                 <p className='text-base sm:text-xs'><span
                                     className="font-semibold">Posted at: {TimeHandler(postTime).hours}:{TimeHandler(postTime).minutes}{TimeHandler(postTime).amOrPm}, {TimeHandler(postTime).day}-{TimeHandler(postTime).month}-{TimeHandler(postTime).year}</span>
                                 </p>
                                 {note.author?.id === userId &&
                                     <DeleteButton itemID={note.id} activeTab='notes'/>
                                 }
+                                <ShareLink fileType='these Notes'/>
                             </div>
                         </div>
                     </div>

--- a/app/@protected_routes/past_papers/[id]/page.tsx
+++ b/app/@protected_routes/past_papers/[id]/page.tsx
@@ -6,6 +6,7 @@ import {TimeHandler} from '@/app/components/forumpost/CommentContainer';
 import DeleteButton from '@/app/components/DeleteButton';
 import {Metadata} from "next";
 import {notFound} from "next/navigation";
+import ShareLink from '@/app/components/ShareLink';
 
 function removePdfExtension(filename: string): string {
     return filename.endsWith('.pdf') ? filename.slice(0, -4) : filename;
@@ -100,12 +101,13 @@ async function PdfViewerPage({params}: { params: { id: string } }) {
                             <p className="text-base sm:text-lg"><span
                                 className="font-semibold">Posted by: </span> {paper.author?.name?.slice(0, -10) || 'Unknown'}
                             </p>
-                            <div className="flex gap-2 items-center">
+                            <div className="flex gap-2 items-center justify-between">
                                 <p className='text-base sm:text-xs'><span
                                     className="font-semibold">Posted at: {TimeHandler(postTime).hours}:{TimeHandler(postTime).minutes}{TimeHandler(postTime).amOrPm}, {TimeHandler(postTime).day}-{TimeHandler(postTime).month}-{TimeHandler(postTime).year}</span>
                                 </p>
                                 {userId === paper.author.id &&
                                     <DeleteButton itemID={paper.id} activeTab="pastPaper"/>}
+                                <ShareLink fileType='this Past Paper'/>
                             </div>
                         </div>
                     </div>

--- a/app/components/ShareLink.tsx
+++ b/app/components/ShareLink.tsx
@@ -3,7 +3,7 @@ import { faShareNodes } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import React, { useEffect, useState } from 'react'
 
-const ShareLink = ({fileType} : {fileType:string}) => {
+const ShareLink = ({ fileType }: { fileType: string }) => {
 
     const [isVisible, setisVisible] = useState(false);
 
@@ -32,33 +32,20 @@ const ShareLink = ({fileType} : {fileType:string}) => {
 
     return (
         <button onClick={handleClick}>
-            <div className="group relative block md:hidden">
+            <div className="group relative">
                 <div className={`
                 px-3 py-2 absolute right-0 bottom-0 -translate-y-full
-                text-white dark:text-[#232530] text-sm font-medium 
+                text-white dark:text-[#232530] text-sm font-medium break-normal 
 
                 bg-gradient-to-b from-[#5fc4e7] to-[#4db3d6] dark:from-[#3BF4C7] dark:to-[#2ad3a7] shadow-lg rounded-md
                 transition-all duration-300 ease-in-out
-                ${isVisible ? 'opacity-100 -translate-y-0' : 'opacity-0 translate-y-1'}
+                ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-1'}
                 `}
                 >
                     Copied!
                 </div>
             </div>
             <FontAwesomeIcon icon={faShareNodes} />
-            <div className="group relative hidden md:block">
-                <div className={`
-                px-3 py-2 absolute right-0 translate-x-1/2 
-                text-white dark:text-[#232530] text-sm font-medium 
-
-                bg-gradient-to-b from-[#5fc4e7] to-[#4db3d6] dark:from-[#3BF4C7] dark:to-[#2ad3a7] shadow-lg rounded-md
-                transition-all duration-300 ease-in-out
-                ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-1'}
-                `}
-                >
-                    Copied!
-                </div>
-            </div>
         </button>
     );
 }

--- a/app/components/ShareLink.tsx
+++ b/app/components/ShareLink.tsx
@@ -3,20 +3,6 @@ import { faShareNodes } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import React, { useEffect, useState } from 'react'
 
-
-const IndicatorOfSuccess = () => {
-    return (
-        <div className="group relative">
-            <div
-                className="absolute left-full ml-2 top-1/2 -translate-y-1/2 px-3 py-2 bg-gradient-to-r from-[#5fc4e7] to-[#4db3d6] dark:from-[#3BF4C7] dark:to-[#2ad3a7] text-white dark:text-[#232530] rounded-md text-sm opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 ease-in-out z-50 whitespace-nowrap shadow-lg backdrop-blur-sm backdrop-filter max-w-xs break-words">
-                <span className="font-medium">Copied Link!</span>
-                <div
-                    className="absolute w-0 h-0 border-t-[6px] border-b-[6px] border-r-[6px] border-transparent border-r-[#5fc4e7] dark:border-r-[#3BF4C7] -left-[6px] top-1/2 -translate-y-1/2 transform transition-transform duration-300 ease-in-out group-hover:scale-110"></div>
-            </div>
-        </div>
-    )
-}
-
 const ShareLink = ({fileType} : {fileType:string}) => {
 
     const [isVisible, setisVisible] = useState(false);

--- a/app/components/ShareLink.tsx
+++ b/app/components/ShareLink.tsx
@@ -1,0 +1,80 @@
+"use client"
+import { faShareNodes } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import React, { useEffect, useState } from 'react'
+
+
+const IndicatorOfSuccess = () => {
+    return (
+        <div className="group relative">
+            <div
+                className="absolute left-full ml-2 top-1/2 -translate-y-1/2 px-3 py-2 bg-gradient-to-r from-[#5fc4e7] to-[#4db3d6] dark:from-[#3BF4C7] dark:to-[#2ad3a7] text-white dark:text-[#232530] rounded-md text-sm opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 ease-in-out z-50 whitespace-nowrap shadow-lg backdrop-blur-sm backdrop-filter max-w-xs break-words">
+                <span className="font-medium">Copied Link!</span>
+                <div
+                    className="absolute w-0 h-0 border-t-[6px] border-b-[6px] border-r-[6px] border-transparent border-r-[#5fc4e7] dark:border-r-[#3BF4C7] -left-[6px] top-1/2 -translate-y-1/2 transform transition-transform duration-300 ease-in-out group-hover:scale-110"></div>
+            </div>
+        </div>
+    )
+}
+
+const ShareLink = ({fileType} : {fileType:string}) => {
+
+    const [isVisible, setisVisible] = useState(false);
+
+    const copyToClipboard = () => {
+        const msg: string = `Dude! Checkout ${fileType}! ${location.href}`;
+        navigator.clipboard.writeText(msg);
+    }
+
+    const handleClick = () => {
+        setisVisible(true);
+        copyToClipboard();
+    }
+
+    useEffect(() => {
+        let timer: NodeJS.Timeout;
+        if (isVisible) {
+            timer = setTimeout(() => {
+                setisVisible(false)
+            }, 3000)
+        }
+        return (
+            () => clearTimeout(timer)
+        );
+
+    }, [isVisible])
+
+    return (
+        <button onClick={handleClick}>
+            <div className="group relative block md:hidden">
+                <div className={`
+                px-3 py-2 absolute right-0 bottom-0 -translate-y-full
+                text-white dark:text-[#232530] text-sm font-medium 
+
+                bg-gradient-to-b from-[#5fc4e7] to-[#4db3d6] dark:from-[#3BF4C7] dark:to-[#2ad3a7] shadow-lg rounded-md
+                transition-all duration-300 ease-in-out
+                ${isVisible ? 'opacity-100 -translate-y-0' : 'opacity-0 translate-y-1'}
+                `}
+                >
+                    Copied!
+                </div>
+            </div>
+            <FontAwesomeIcon icon={faShareNodes} />
+            <div className="group relative hidden md:block">
+                <div className={`
+                px-3 py-2 absolute right-0 translate-x-1/2 
+                text-white dark:text-[#232530] text-sm font-medium 
+
+                bg-gradient-to-b from-[#5fc4e7] to-[#4db3d6] dark:from-[#3BF4C7] dark:to-[#2ad3a7] shadow-lg rounded-md
+                transition-all duration-300 ease-in-out
+                ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-1'}
+                `}
+                >
+                    Copied!
+                </div>
+            </div>
+        </button>
+    );
+}
+
+export default ShareLink;


### PR DESCRIPTION
## Used the same tooltip as the navbar to indicate that you have copied something

The msg that gets copied is : "Dude! Checkout ${fileType}! LINK", where fileType is either "this Past Paper" or "these Notes"

#### Small change: Made the position of the "Copied" msg the same for both smaller and bigger screens, screenshots have been updated to show that

Screenshots:
![screenshot-20241007-14:42:06](https://github.com/user-attachments/assets/01b5e829-3a5e-4897-a276-de651a1f2b08)
![screenshot-20241007-14:42:23](https://github.com/user-attachments/assets/87b3844f-3b43-434c-a5fb-1617e7f20ee9)
![screenshot-20241007-14:41:45](https://github.com/user-attachments/assets/e02e8796-3343-4905-aac9-da4487b8139c)
![image](https://github.com/user-attachments/assets/cdac690d-ed64-47c4-a476-a698d376a179)
