### PR TITLE
fix: update npm configuration and remove unused dependencies

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-auto-install-peers=false
+legacy-peer-deps=true

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,7 +9,6 @@ import PwaServiceWorker from "@/app/components/pwa-service-worker";
 import CapacitorBridge from "@/app/components/capacitor-bridge";
 import NativeIosTabSync from "@/app/components/native-ios-tab-sync";
 import AndroidInstallBanner from "@/app/components/android-install-banner";
-import { GoogleAnalytics } from "@next/third-parties/google";
 import type { Metadata, Viewport } from "next";
 import { DEFAULT_KEYWORDS, getBaseUrl } from "@/lib/seo";
 import StructuredData from "@/app/components/seo/structured-data";
@@ -84,6 +83,23 @@ export const metadata: Metadata = {
     },
 };
 const plus_jakarta_sans = Plus_Jakarta_Sans({ subsets: ["latin"] });
+
+function GoogleAnalytics({ gaId }: { gaId: string }) {
+    return (
+        <>
+            <Script
+                src={`https://www.googletagmanager.com/gtag/js?id=${encodeURIComponent(gaId)}`}
+                strategy="afterInteractive"
+            />
+            <Script id="google-analytics" strategy="afterInteractive">
+                {`window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date());
+gtag('config', ${JSON.stringify(gaId)});`}
+            </Script>
+        </>
+    );
+}
 
 export default function RootLayout({
     children,

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "@fortawesome/react-fontawesome": "^3.3.1",
     "@modelcontextprotocol/ext-apps": "^1.7.4",
     "@modelcontextprotocol/sdk": "1.29.0",
-    "@next/third-parties": "16.3.0-preview.5",
     "@openai/agents": "^0.12.0",
     "@posthog/react": "^1.10.3",
     "@radix-ui/react-dialog": "^1.1.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,9 +98,6 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: 1.29.0
         version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
-      '@next/third-parties':
-        specifier: 16.3.0-preview.5
-        version: 16.3.0-preview.5(next@16.3.0-preview.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       '@openai/agents':
         specifier: ^0.12.0
         version: 0.12.0(@cfworker/json-schema@4.1.1)(ws@8.21.0)(zod@4.4.3)
@@ -1479,12 +1476,6 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
-
-  '@next/third-parties@16.3.0-preview.5':
-    resolution: {integrity: sha512-4i1Nrm3TZia0pOBqq1aChpdkjzDigyPdGdGGLI3zIw/pgCQEGVDRNNXqKSVXqKDgkNM7QLIdPNSYqg/7INHFXQ==}
-    peerDependencies:
-      next: ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0-beta.0
-      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
 
   '@nodable/entities@2.1.0':
     resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
@@ -4955,9 +4946,6 @@ packages:
     resolution: {integrity: sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==}
     engines: {node: '>=18'}
 
-  third-party-capital@1.0.20:
-    resolution: {integrity: sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==}
-
   three@0.184.0:
     resolution: {integrity: sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==}
 
@@ -6396,12 +6384,6 @@ snapshots:
 
   '@next/swc-win32-x64-msvc@16.3.0-preview.5':
     optional: true
-
-  '@next/third-parties@16.3.0-preview.5(next@16.3.0-preview.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      next: 16.3.0-preview.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react: 19.2.7
-      third-party-capital: 1.0.20
 
   '@nodable/entities@2.1.0': {}
 
@@ -10190,8 +10172,6 @@ snapshots:
       minipass: 7.1.3
       minizlib: 3.1.0
       yallist: 5.0.0
-
-  third-party-capital@1.0.20: {}
 
   three@0.184.0: {}
 


### PR DESCRIPTION
<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR removes the third-party Google Analytics package and updates install configuration. The main changes are:

- Replaces `@next/third-parties/google` with a local `GoogleAnalytics` component.
- Removes `@next/third-parties` from `package.json` and the pnpm lockfile.
- Changes the root `.npmrc` install behavior.

<h3>Confidence Score: 2/5</h3>

The dependency installation path still needs attention because committed package-manager configuration can allow incompatible installs and frozen pnpm installation evidence shows the lockfile is not accepted as committed.

- `.npmrc` changes npm resolution behavior for deployment installs that do not use a package lock.
- Runtime validation also showed `pnpm install --frozen-lockfile --ignore-scripts` failing with a lockfile configuration mismatch, which means the dependency update is not cleanly reproducible in a frozen install path.
- The Google Analytics dependency removal was partially exercised, but install/build validation did not complete cleanly enough to treat the package changes as fully safe.

.npmrc and pnpm-lock.yaml

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- During the base checkout, it succeeded, the @next/third-parties dependency was 16.3.0-preview.5, and the frozen pnpm install failed due to a lockfile override mismatch.
- During the head checkout, the head checkout succeeded with @next/third-parties absent; a lockfile grep produced no occurrences and the frozen pnpm install again failed on the same override mismatch.
- Using the fallback path, a non-frozen install completed and the Next production build reached successful compilation before stalling at TypeScript.
- The render step exited with code 0, but the static render output did not include the GA script URL or GA ID.

<a href="https://app.greptile.com/trex/runs/12348242/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Frozen pnpm install fails because lockfile overrides do not match package configuration**

   - **Bug**
     - On the head revision, `pnpm install --frozen-lockfile --ignore-scripts` fails before build with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`. The PR contract includes package/lockfile install compatibility, but the committed lockfile is not accepted by pnpm in frozen mode. This blocks a normal CI-style frozen install/build validation.
   - **Cause**
     - The override configuration stored in `pnpm-lock.yaml` does not match the current package configuration as interpreted by pnpm. The log shows pnpm refusing frozen installation and requesting `pnpm install --no-frozen-lockfile`.
   - **Fix**
     - Regenerate and commit `pnpm-lock.yaml` with the same pnpm version/configuration expected in CI, then rerun `pnpm install --frozen-lockfile` successfully. Ensure the committed lockfile reflects the package overrides after removing `@next/third-parties`.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22acm-vit%2Fexamcooker%22%20on%20the%20existing%20branch%20%22dev%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22dev%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.npmrc%3A1%0A**Peer%20Checks%20Disabled%20In%20CI**%0A%0AThe%20deployment%20workflows%20run%20%60npm%20install%20--no-fund%20--no-audit%60%2C%20and%20npm%20reads%20this%20new%20%60legacy-peer-deps%3Dtrue%60%20setting.%20Because%20the%20repo%20has%20no%20%60package-lock.json%60%2C%20CI%20now%20resolves%20dependencies%20from%20scratch%20while%20ignoring%20peer%20dependency%20conflicts%2C%20so%20an%20incompatible%20peer%20tree%20can%20be%20deployed%20instead%20of%20failing%20during%20install.%0A%0A%60%60%60suggestion%0Aauto-install-peers%3Dfalse%0A%60%60%60%0A%0A&repo=acm-vit%2Fexamcooker&pr=454&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.npmrc%3A1%0A**Peer%20Checks%20Disabled%20In%20CI**%0A%0AThe%20deployment%20workflows%20run%20%60npm%20install%20--no-fund%20--no-audit%60%2C%20and%20npm%20reads%20this%20new%20%60legacy-peer-deps%3Dtrue%60%20setting.%20Because%20the%20repo%20has%20no%20%60package-lock.json%60%2C%20CI%20now%20resolves%20dependencies%20from%20scratch%20while%20ignoring%20peer%20dependency%20conflicts%2C%20so%20an%20incompatible%20peer%20tree%20can%20be%20deployed%20instead%20of%20failing%20during%20install.%0A%0A%60%60%60suggestion%0Aauto-install-peers%3Dfalse%0A%60%60%60%0A%0A&repo=acm-vit%2Fexamcooker&pr=454&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.npmrc%3A1%0A**Peer%20Checks%20Disabled%20In%20CI**%0A%0AThe%20deployment%20workflows%20run%20%60npm%20install%20--no-fund%20--no-audit%60%2C%20and%20npm%20reads%20this%20new%20%60legacy-peer-deps%3Dtrue%60%20setting.%20Because%20the%20repo%20has%20no%20%60package-lock.json%60%2C%20CI%20now%20resolves%20dependencies%20from%20scratch%20while%20ignoring%20peer%20dependency%20conflicts%2C%20so%20an%20incompatible%20peer%20tree%20can%20be%20deployed%20instead%20of%20failing%20during%20install.%0A%0A%60%60%60suggestion%0Aauto-install-peers%3Dfalse%0A%60%60%60%0A%0A&pr=454&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix: update npm configuration and remove..."](https://github.com/acm-vit/examcooker/commit/a4fbbd619c0d34d712860068efb8091969b34109) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39943678)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->