### PR TITLE
Add additional transient DB error message for connection timeout

### DIFF
--- a/db/index.ts
+++ b/db/index.ts
@@ -43,11 +43,15 @@ const TRANSIENT_DB_ERROR_CODES = new Set([
 ]);
 
 const TRANSIENT_DB_ERROR_MESSAGES = [
+  "connection terminated due to connection timeout",
   "connection terminated unexpectedly",
   "query read timeout",
   "read econnreset",
   "read etimedout",
   "socket hang up",
+  // pg-pool acquisition timeout (connectionTimeoutMillis) — the query never
+  // reached the server, so retrying is always safe.
+  "timeout exceeded when trying to connect",
 ];
 
 type RetryableDbError = Error & {

--- a/lib/mcp/examcooker-widget.ts
+++ b/lib/mcp/examcooker-widget.ts
@@ -73,12 +73,12 @@ export const EXAMCOOKER_WIDGET_HTML = `<!doctype html>
      rounded panel mask. Padding on the inner wrapper survives the host reset,
      so the breathing room actually reflects. */
   body { margin: 0; padding: 0; }
-  .root { max-width: 1080px; margin: 0 auto; padding: 32px 34px 36px; }
+  .root { max-width: 1080px; margin: 0 auto; padding: 44px 40px 40px; }
   @media (max-width: 720px) {
-    .root { padding: 24px 22px 28px; }
+    .root { padding: 32px 24px 30px; }
   }
   @media (max-width: 480px) {
-    .root { padding: 20px 16px 24px; }
+    .root { padding: 26px 18px 26px; }
   }
 
   .status { display: flex; align-items: center; justify-content: center; padding: 56px 16px; color: var(--ec-text-muted); font-size: 13px; font-weight: 500; gap: 10px; }


### PR DESCRIPTION
<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR updates database retry handling and widget spacing. The main changes are:

- Adds connection timeout message snippets to transient database error matching.
- Keeps retry behavior scoped to the existing safe query retry path.
- Increases ExamCooker widget root padding across desktop and responsive breakpoints.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The changes are small and localized. The database update follows the existing transient error matching pattern. The widget update only adjusts CSS padding values.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Compared base dade0d436a4b1d8df8fadfb81f224065e798a3b0 to head 2aa4f63e3b744fedaacb12d584ab553c5a862ba7, and observed that the head retried both messages (attempts=2, retried=true) and returned a successful SELECT.
- Captured before/after widget padding visuals with screenshots and videos to verify UI padding changes across commits.
- Reviewed the padding measurement artifacts, including before/after screenshots, videos, and the capture script output containing computed padding measurements.

<a href="https://app.greptile.com/trex/runs/13235228/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| db/index.ts | Adds additional transient PostgreSQL/pg-pool timeout message matching to the existing retry classification path; no issues found. |
| lib/mcp/examcooker-widget.ts | Adjusts widget root padding across desktop and responsive breakpoints; no issues found. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
  participant App as Application query
  participant Pool as pg Pool query wrapper
  participant Match as Transient error matcher
  participant DB as Database

  App->>Pool: SELECT/SHOW query
  Pool->>DB: rawQuery(...args)
  alt transient connection timeout
    DB-->>Pool: timeout error message
    Pool->>Match: isTransientDbError(error)
    Match-->>Pool: true when message includes connection timeout snippet
    Pool->>Pool: wait retry delay
    Pool->>DB: retry rawQuery(...args)
  else success or non-transient failure
    DB-->>Pool: result or final error
    Pool-->>App: result or throw
  end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
  participant App as Application query
  participant Pool as pg Pool query wrapper
  participant Match as Transient error matcher
  participant DB as Database

  App->>Pool: SELECT/SHOW query
  Pool->>DB: rawQuery(...args)
  alt transient connection timeout
    DB-->>Pool: timeout error message
    Pool->>Match: isTransientDbError(error)
    Match-->>Pool: true when message includes connection timeout snippet
    Pool->>Pool: wait retry delay
    Pool->>DB: retry rawQuery(...args)
  else success or non-transient failure
    DB-->>Pool: result or final error
    Pool-->>App: result or throw
  end
```

</a>

<sub>Reviews (1): Last reviewed commit: ["Add additional transient DB error messag..."](https://github.com/acm-vit/examcooker/commit/2aa4f63e3b744fedaacb12d584ab553c5a862ba7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41727922)</sub>

<!-- /greptile_comment -->