### PR TITLE
resync

### DIFF
--- a/lib/pdf/pdf-buffer-cache.ts
+++ b/lib/pdf/pdf-buffer-cache.ts
@@ -11,11 +11,25 @@ const MAX_CACHE_ENTRIES = 8;
 const PDF_DOWNLOAD_STALL_TIMEOUT_MS = 15000;
 const pdfBufferCache = new Map<string, PdfBufferCacheEntry>();
 
+function evictPdfBufferEntry(fileUrl: string, entry: PdfBufferCacheEntry) {
+  pdfBufferCache.delete(fileUrl);
+
+  if (entry.listeners.size === 0) {
+    entry.abort?.();
+  }
+}
+
 function trimCache() {
   while (pdfBufferCache.size > MAX_CACHE_ENTRIES) {
     const oldestKey = pdfBufferCache.keys().next().value as string | undefined;
     if (!oldestKey) return;
-    pdfBufferCache.delete(oldestKey);
+    const oldestEntry = pdfBufferCache.get(oldestKey);
+    if (!oldestEntry) {
+      pdfBufferCache.delete(oldestKey);
+      continue;
+    }
+
+    evictPdfBufferEntry(oldestKey, oldestEntry);
   }
 }
 


### PR DESCRIPTION
<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR updates PDF buffer cache eviction to cancel unused downloads.

- Adds a shared cache-entry eviction helper.
- Aborts evicted downloads that have no listeners.
- Uses the helper while trimming the cache.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues were found in the changed code. Entries with active listeners continue downloading, and deleting or aborting an already settled entry is harmless.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reviewed the general-contract-validation-proof and examined pdf-cache-eviction-01-before.log to observe that the parent revision leaves an evicted listener-free preload running and fails the expected-abort assertion.
- Validated the after-state by inspecting pdf-cache-eviction-02-after.log and confirming the head records exactly one abort for the oldest listener-free request and passes.
- Verified the active-listener before/after captures show zero aborts, successful completion, progress notification, and safe unsubscribe.
- Acknowledged that the reusable TypeScript harness and the parent-revision implementation snapshot are included to enable reproduction.

<a href="https://app.greptile.com/trex/runs/14144598/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/pdf/pdf-buffer-cache.ts | Centralizes cache eviction and aborts listener-free downloads when they are evicted. |

<sub>Reviews (1): Last reviewed commit: ["Merge pull request #461 from ACM-VIT/cur..."](https://github.com/acm-vit/examcooker/commit/d07aec668b35add1f095749bd071e9f7085bac8b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43622171)</sub>

<!-- /greptile_comment -->