### PR TITLE
Dev

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,3 @@
+{
+  "install": "pnpm install --frozen-lockfile --prefer-offline"
+}

--- a/app/components/common/directional-transition.tsx
+++ b/app/components/common/directional-transition.tsx
@@ -3,6 +3,16 @@
 import React, { ViewTransition, useEffect, useState } from "react";
 import { usePathname } from "next/navigation";
 
+// `<ViewTransition>` is an experimental React API. On interrupted navigations it
+// can read `_retryCache` off a null Offscreen instance and throw an unhandled
+// `TypeError` when `<Suspense>` boundaries are torn down mid-transition (which they
+// are on every app route, since pages nest Suspense inside this keyed transition).
+// Keep it behind an opt-in flag so we can validate the experimental path before
+// enabling it broadly; when disabled we render children directly with no animation.
+function pageViewTransitionsEnabled() {
+    return process.env.NEXT_PUBLIC_ENABLE_VIEW_TRANSITIONS === "true";
+}
+
 function hasNativeShellAttributes() {
     if (typeof document === "undefined") return false;
     const root = document.documentElement;
@@ -41,7 +51,7 @@ export default function DirectionalTransition({
     const pathname = usePathname();
     const disablePageViewTransitions = useDisablePageViewTransitions();
 
-    if (disablePageViewTransitions) {
+    if (!pageViewTransitionsEnabled() || disablePageViewTransitions) {
         return <>{children}</>;
     }
 

--- a/app/components/past_papers/course-paper-card.tsx
+++ b/app/components/past_papers/course-paper-card.tsx
@@ -119,6 +119,7 @@ function CoursePaperCard({
                 year: paper.year,
                 hasAnswerKey: paper.hasAnswerKey,
             }),
+            pageEdits: paper.pageEdits,
         });
     }, [courseCode, courseTitle, paper]);
 

--- a/app/components/past_papers/course-paper-grid.tsx
+++ b/app/components/past_papers/course-paper-grid.tsx
@@ -239,6 +239,7 @@ export default function CoursePaperGrid({
                         year: paper.year,
                         hasAnswerKey: paper.hasAnswerKey,
                     }),
+                    pageEdits: paper.pageEdits,
                 })),
             });
 
@@ -350,6 +351,7 @@ export default function CoursePaperGrid({
         void downloadPdfFile({
             fileUrl: paper.fileUrl,
             fileName: getPaperFileName(paper),
+            pageEdits: paper.pageEdits,
         });
         closeContextMenu();
     }, [closeContextMenu, getPaperFileName]);

--- a/app/components/pdfviewer.tsx
+++ b/app/components/pdfviewer.tsx
@@ -1131,6 +1131,22 @@ function AiPaperView({
 
 }
 
+// Rasterized PDF pages are shown as images. We deliberately use a data: URL
+// rather than URL.createObjectURL(blob): blob: URLs are scoped to the live
+// document and cannot be serialized by session-replay tooling (rrweb), so every
+// page shows as a broken/blank image during replay playback even though the
+// user saw it fine. A data: URL embeds the pixels inline, so it is
+// replay-recordable.
+function blobToDataUrl(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () =>
+      reject(reader.error ?? new Error("Failed to read rendered page blob."));
+    reader.readAsDataURL(blob);
+  });
+}
+
 function PageRenderLayer({
   documentId,
   isPdfDarkMode,
@@ -1143,13 +1159,16 @@ function PageRenderLayer({
   const { provides: renderProvides } = useRenderCapability();
   const documentState = useDocumentState(documentId);
   const [imageUrl, setImageUrl] = useState<string | null>(null);
-  const imageUrlRef = useRef<string | null>(null);
+  const [hasRenderError, setHasRenderError] = useState(false);
+  const [retryVersion, setRetryVersion] = useState(0);
   const refreshVersion = documentState?.pageRefreshVersions[pageIndex] ?? 0;
 
   useEffect(() => {
     if (!renderProvides || documentState?.status !== "loaded") return;
 
     let isCurrentRender = true;
+    setHasRenderError(false);
+
     const task = renderProvides.forDocument(documentId).renderPage({
       pageIndex,
       options: {
@@ -1161,15 +1180,10 @@ function PageRenderLayer({
 
     task
       .toPromise()
-      .then((blob) => {
+      .then((blob) => blobToDataUrl(blob))
+      .then((dataUrl) => {
         if (!isCurrentRender) return;
-
-        const nextImageUrl = URL.createObjectURL(blob);
-        if (imageUrlRef.current) {
-          URL.revokeObjectURL(imageUrlRef.current);
-        }
-        imageUrlRef.current = nextImageUrl;
-        setImageUrl(nextImageUrl);
+        setImageUrl(dataUrl);
       })
       .catch((renderError) => {
         if (!isCurrentRender) return;
@@ -1178,6 +1192,7 @@ function PageRenderLayer({
           pageIndex,
           renderError,
         });
+        setHasRenderError(true);
       });
 
     return () => {
@@ -1190,19 +1205,20 @@ function PageRenderLayer({
     documentState?.status,
     pageIndex,
     refreshVersion,
+    retryVersion,
     renderProvides,
-    imageUrlRef,
   ]);
 
-  useEffect(
-    () => () => {
-      if (imageUrlRef.current) {
-        URL.revokeObjectURL(imageUrlRef.current);
-        imageUrlRef.current = null;
-      }
-    },
-    [imageUrlRef]
-  );
+  const handleRetry = useCallback(() => {
+    setHasRenderError(false);
+    setRetryVersion((version) => version + 1);
+  }, []);
+
+  // A page render can genuinely fail (e.g. "Error creating WebGL context.").
+  // Surface a recoverable fallback instead of a silent blank page.
+  if (hasRenderError) {
+    return <PageRenderError isPdfDarkMode={isPdfDarkMode} onRetry={handleRetry} />;
+  }
 
   if (!imageUrl) return null;
 
@@ -1220,6 +1236,33 @@ function PageRenderLayer({
       draggable={false}
       style={isPdfDarkMode ? { filter: PDF_DARK_MODE_FILTER } : undefined}
     />
+  );
+}
+
+function PageRenderError({
+  isPdfDarkMode,
+  onRetry,
+}: {
+  isPdfDarkMode: boolean;
+  onRetry: () => void;
+}) {
+  return (
+    <div
+      className={`absolute inset-0 flex flex-col items-center justify-center gap-3 px-4 text-center text-sm ${
+        isPdfDarkMode ? "bg-black text-gray-300" : "bg-white text-gray-600"
+      }`}
+      data-ec-pdf-page-error="true"
+    >
+      <AlertCircle className="size-6 text-red-500" aria-hidden="true" />
+      <p>This page couldn&apos;t be rendered.</p>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="rounded border border-black/15 bg-white px-3 py-1.5 font-semibold text-black transition hover:border-black/30 dark:border-white/15 dark:bg-gray-900 dark:text-gray-100 dark:hover:border-white/30"
+      >
+        Retry
+      </button>
+    </div>
   );
 }
 

--- a/app/components/pdfviewer.tsx
+++ b/app/components/pdfviewer.tsx
@@ -1228,6 +1228,7 @@ function ViewerToolbar({
   enableQuestionMarkdown,
   fileUrl,
   fileName,
+  pageEdits,
   isFullScreen,
   isPdfDarkMode,
   viewMode,
@@ -1243,6 +1244,7 @@ function ViewerToolbar({
   enableQuestionMarkdown: boolean;
   fileUrl: string;
   fileName: string;
+  pageEdits: PdfPageEdits | null;
   isFullScreen: boolean;
   isPdfDarkMode: boolean;
   viewMode: PaperViewMode;
@@ -1331,11 +1333,11 @@ function ViewerToolbar({
     setIsDownloading(true);
     capturePdfDownloaded({ fileName, fileUrl });
     try {
-      await downloadPdfFile({ fileUrl, fileName });
+      await downloadPdfFile({ fileUrl, fileName, pageEdits });
     } finally {
       setIsDownloading(false);
     }
-  }, [fileName, fileUrl, isDownloading]);
+  }, [fileName, fileUrl, isDownloading, pageEdits]);
 
   const handleViewMarkdown = useCallback(() => {
     setIsMarkdownMenuOpen(false);
@@ -1874,6 +1876,7 @@ function LoadedDocumentSurface({
             enableQuestionMarkdown={enableQuestionMarkdown}
             fileUrl={fileUrl}
             fileName={fileName}
+            pageEdits={pageEdits}
             isFullScreen={isFullScreen}
             isPdfDarkMode={isPdfDarkMode}
             viewMode={viewMode}

--- a/app/components/pdfviewer.tsx
+++ b/app/components/pdfviewer.tsx
@@ -1131,20 +1131,8 @@ function AiPaperView({
 
 }
 
-// Rasterized PDF pages are shown as images. We deliberately use a data: URL
-// rather than URL.createObjectURL(blob): blob: URLs are scoped to the live
-// document and cannot be serialized by session-replay tooling (rrweb), so every
-// page shows as a broken/blank image during replay playback even though the
-// user saw it fine. A data: URL embeds the pixels inline, so it is
-// replay-recordable.
-function blobToDataUrl(blob: Blob): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = () => resolve(reader.result as string);
-    reader.onerror = () =>
-      reject(reader.error ?? new Error("Failed to read rendered page blob."));
-    reader.readAsDataURL(blob);
-  });
+function blobToObjectUrl(blob: Blob) {
+  return URL.createObjectURL(blob);
 }
 
 function PageRenderLayer({
@@ -1180,10 +1168,18 @@ function PageRenderLayer({
 
     task
       .toPromise()
-      .then((blob) => blobToDataUrl(blob))
-      .then((dataUrl) => {
-        if (!isCurrentRender) return;
-        setImageUrl(dataUrl);
+      .then((blob) => {
+        const nextImageUrl = blobToObjectUrl(blob);
+        if (!isCurrentRender) {
+          URL.revokeObjectURL(nextImageUrl);
+          return;
+        }
+        setImageUrl((previousImageUrl) => {
+          if (previousImageUrl && previousImageUrl !== nextImageUrl) {
+            URL.revokeObjectURL(previousImageUrl);
+          }
+          return nextImageUrl;
+        });
       })
       .catch((renderError) => {
         if (!isCurrentRender) return;
@@ -1208,6 +1204,15 @@ function PageRenderLayer({
     retryVersion,
     renderProvides,
   ]);
+
+  useEffect(
+    () => () => {
+      if (imageUrl) {
+        URL.revokeObjectURL(imageUrl);
+      }
+    },
+    [imageUrl],
+  );
 
   const handleRetry = useCallback(() => {
     setHasRenderError(false);

--- a/app/global-error-reload-guard.ts
+++ b/app/global-error-reload-guard.ts
@@ -1,0 +1,74 @@
+const RELOAD_FLAG = "examcooker:chunk-reload";
+const RELOAD_GUARD_TTL_MS = 60_000;
+
+type ReloadGuard = {
+  key: string;
+  timestamp: number;
+};
+
+export function isChunkLoadError(error: unknown): boolean {
+  if (!error) return false;
+  const candidate = error as { name?: unknown; message?: unknown };
+  const name = typeof candidate.name === "string" ? candidate.name : "";
+  const message = typeof candidate.message === "string" ? candidate.message : "";
+  return (
+    name === "ChunkLoadError" ||
+    /Loading chunk [\w-]+ failed/i.test(message) ||
+    /Failed to load chunk/i.test(message) ||
+    /Loading CSS chunk/i.test(message)
+  );
+}
+
+export function getChunkErrorKey(error: Error & { digest?: string }): string {
+  return [
+    error.name || "Error",
+    error.message || "",
+    error.digest || "",
+  ].join(":");
+}
+
+function readReloadGuard(): ReloadGuard | null {
+  try {
+    const rawGuard = window.sessionStorage.getItem(RELOAD_FLAG);
+    if (!rawGuard) return null;
+
+    const guard = JSON.parse(rawGuard) as Partial<ReloadGuard>;
+    if (typeof guard.key !== "string" || typeof guard.timestamp !== "number") {
+      return null;
+    }
+    return { key: guard.key, timestamp: guard.timestamp };
+  } catch {
+    return null;
+  }
+}
+
+function writeReloadGuard(key: string): boolean {
+  try {
+    window.sessionStorage.setItem(
+      RELOAD_FLAG,
+      JSON.stringify({ key, timestamp: Date.now() }),
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function clearReloadGuard() {
+  try {
+    window.sessionStorage.removeItem(RELOAD_FLAG);
+  } catch {
+    // Ignore storage access errors.
+  }
+}
+
+export function hasFreshReloadGuard(key: string): boolean {
+  const guard = readReloadGuard();
+  if (!guard) return false;
+  return guard.key === key && Date.now() - guard.timestamp < RELOAD_GUARD_TTL_MS;
+}
+
+export function claimChunkReload(key: string): boolean {
+  if (hasFreshReloadGuard(key)) return false;
+  return writeReloadGuard(key);
+}

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,81 +1,18 @@
 "use client";
 
 import { useEffect } from "react";
-
-const RELOAD_FLAG = "examcooker:chunk-reload";
-const RELOAD_GUARD_TTL_MS = 60_000;
-
-type ReloadGuard = {
-    key: string;
-    timestamp: number;
-};
+import {
+  claimChunkReload,
+  clearReloadGuard,
+  getChunkErrorKey,
+  isChunkLoadError,
+} from "./global-error-reload-guard";
 
 type GlobalErrorProps = {
     error: Error & { digest?: string };
     unstable_retry?: () => void;
     reset?: () => void;
 };
-
-function isChunkLoadError(error: unknown): boolean {
-  if (!error) return false;
-  const candidate = error as { name?: unknown; message?: unknown };
-  const name = typeof candidate.name === "string" ? candidate.name : "";
-  const message = typeof candidate.message === "string" ? candidate.message : "";
-  return (
-    name === "ChunkLoadError" ||
-    /Loading chunk [\w-]+ failed/i.test(message) ||
-    /Failed to load chunk/i.test(message) ||
-    /Loading CSS chunk/i.test(message)
-  );
-}
-
-function getChunkErrorKey(error: Error & { digest?: string }): string {
-    return [
-        error.name || "Error",
-        error.message || "",
-        error.digest || "",
-    ].join(":");
-}
-
-function readReloadGuard(): ReloadGuard | null {
-    try {
-        const rawGuard = window.sessionStorage.getItem(RELOAD_FLAG);
-        if (!rawGuard) return null;
-
-        const guard = JSON.parse(rawGuard) as Partial<ReloadGuard>;
-        if (typeof guard.key !== "string" || typeof guard.timestamp !== "number") {
-            return null;
-        }
-        return { key: guard.key, timestamp: guard.timestamp };
-    } catch {
-        return null;
-    }
-}
-
-function writeReloadGuard(key: string) {
-    try {
-        window.sessionStorage.setItem(
-            RELOAD_FLAG,
-            JSON.stringify({ key, timestamp: Date.now() }),
-        );
-    } catch {
-        // sessionStorage may be unavailable (private mode); ignore it.
-    }
-}
-
-function clearReloadGuard() {
-    try {
-        window.sessionStorage.removeItem(RELOAD_FLAG);
-    } catch {
-        // Ignore storage access errors.
-    }
-}
-
-function hasFreshReloadGuard(key: string): boolean {
-    const guard = readReloadGuard();
-    if (!guard) return false;
-    return guard.key === key && Date.now() - guard.timestamp < RELOAD_GUARD_TTL_MS;
-}
 
 export default function GlobalError({
   error,
@@ -91,11 +28,7 @@ export default function GlobalError({
         // chunks are removed from the server, so a client holding stale HTML
         // requests chunk URLs that 404 and `next/dynamic` throws. Force a
         // guarded reload to pull a fresh HTML document and current chunks.
-        const guardKey = getChunkErrorKey(error);
-        const alreadyReloaded = hasFreshReloadGuard(guardKey);
-
-        if (!alreadyReloaded) {
-            writeReloadGuard(guardKey);
+        if (claimChunkReload(getChunkErrorKey(error))) {
             window.location.reload();
         }
     }, [error, isChunkError]);

--- a/lib/downloads/browser-downloads.ts
+++ b/lib/downloads/browser-downloads.ts
@@ -9,10 +9,13 @@ import {
     canUseNativeFileDownload,
     shareBlobWithNativeDownloads,
 } from "@/lib/native-downloads";
+import { applyPdfPageEditsToBuffer } from "@/lib/pdf/page-edits";
+import type { PdfPageEdits } from "@/lib/pdf/page-edits";
 
 export type DownloadablePdf = {
     fileUrl: string;
     fileName: string;
+    pageEdits?: PdfPageEdits | null;
 };
 
 type ZipEntry = {
@@ -153,6 +156,7 @@ const PDF_FETCH_TIMEOUT_MS = 30_000;
 
 async function fetchPdfBlob(
     fileUrl: string,
+    pageEdits?: PdfPageEdits | null,
     timeoutMs: number = PDF_FETCH_TIMEOUT_MS,
 ) {
     const controller = new AbortController();
@@ -168,10 +172,26 @@ async function fetchPdfBlob(
             throw new Error(`Failed to fetch PDF: ${response.status}`);
         }
 
-        return await response.blob();
+        return await preparePdfDownloadBlob(await response.blob(), pageEdits);
     } finally {
         window.clearTimeout(timeoutId);
     }
+}
+
+export async function preparePdfDownloadBlob(
+    blob: Blob,
+    pageEdits?: PdfPageEdits | null,
+) {
+    if (!pageEdits) {
+        return blob;
+    }
+
+    const editedBuffer = await applyPdfPageEditsToBuffer(
+        await blob.arrayBuffer(),
+        pageEdits,
+    );
+
+    return new Blob([editedBuffer], { type: blob.type || "application/pdf" });
 }
 
 async function saveBlob(blob: Blob, fileName: string) {
@@ -241,11 +261,16 @@ async function createZipBlob(entries: ZipEntry[]) {
     );
 }
 
-export async function downloadPdfFile({ fileUrl, fileName }: DownloadablePdf) {
+export async function downloadPdfFile({ fileUrl, fileName, pageEdits }: DownloadablePdf) {
     try {
-        const blob = await fetchPdfBlob(fileUrl);
+        const blob = await fetchPdfBlob(fileUrl, pageEdits);
         await saveBlob(blob, ensurePdfFileName(fileName));
     } catch {
+        if (pageEdits) {
+            window.alert("Could not prepare the edited PDF for download. Please try again.");
+            return;
+        }
+
         const fallbackLink = document.createElement("a");
         fallbackLink.href = fileUrl;
         fallbackLink.target = "_blank";
@@ -276,7 +301,7 @@ export async function downloadPdfZip(input: {
     // abort the whole batch. A timeout guarantees stalled fetches reject instead
     // of leaving the zip — and the caller's "Zipping..." state — pending forever.
     const settled = await Promise.allSettled(
-        input.files.map((file) => fetchPdfBlob(file.fileUrl)),
+        input.files.map((file) => fetchPdfBlob(file.fileUrl, file.pageEdits)),
     );
 
     const entries: ZipEntry[] = [];

--- a/lib/downloads/browser-downloads.ts
+++ b/lib/downloads/browser-downloads.ts
@@ -9,7 +9,7 @@ import {
     canUseNativeFileDownload,
     shareBlobWithNativeDownloads,
 } from "@/lib/native-downloads";
-import { applyPdfPageEditsToBuffer } from "@/lib/pdf/page-edits";
+import { applyPdfPageEditsToBuffer, hasPdfPageEdits } from "@/lib/pdf/page-edits";
 import type { PdfPageEdits } from "@/lib/pdf/page-edits";
 
 export type DownloadablePdf = {
@@ -182,24 +182,20 @@ export async function preparePdfDownloadBlob(
     blob: Blob,
     pageEdits?: PdfPageEdits | null,
 ) {
-    if (!pageEdits) {
+    const effectivePageEdits = hasPdfPageEdits(pageEdits) ? pageEdits : null;
+    if (!effectivePageEdits) {
         return blob;
     }
 
     const editedBuffer = await applyPdfPageEditsToBuffer(
         await blob.arrayBuffer(),
-        pageEdits,
+        effectivePageEdits,
     );
 
     return new Blob([editedBuffer], { type: blob.type || "application/pdf" });
 }
 
-async function saveBlob(blob: Blob, fileName: string) {
-    if (canUseNativeFileDownload()) {
-        await shareBlobWithNativeDownloads(blob, fileName);
-        return;
-    }
-
+function saveBlobWithBrowserDownload(blob: Blob, fileName: string) {
     const objectUrl = window.URL.createObjectURL(blob);
     const link = document.createElement("a");
 
@@ -210,6 +206,19 @@ async function saveBlob(blob: Blob, fileName: string) {
     link.remove();
 
     window.setTimeout(() => window.URL.revokeObjectURL(objectUrl), 1000);
+}
+
+async function saveBlob(blob: Blob, fileName: string) {
+    if (canUseNativeFileDownload()) {
+        try {
+            await shareBlobWithNativeDownloads(blob, fileName);
+            return;
+        } catch {
+            // Fall back to browser download when native bridge fails.
+        }
+    }
+
+    saveBlobWithBrowserDownload(blob, fileName);
 }
 
 async function createZipBlob(entries: ZipEntry[]) {
@@ -262,11 +271,13 @@ async function createZipBlob(entries: ZipEntry[]) {
 }
 
 export async function downloadPdfFile({ fileUrl, fileName, pageEdits }: DownloadablePdf) {
+    const hasMeaningfulPageEdits = hasPdfPageEdits(pageEdits);
+    let blob: Blob;
+
     try {
-        const blob = await fetchPdfBlob(fileUrl, pageEdits);
-        await saveBlob(blob, ensurePdfFileName(fileName));
+        blob = await fetchPdfBlob(fileUrl, hasMeaningfulPageEdits ? pageEdits : null);
     } catch {
-        if (pageEdits) {
+        if (hasMeaningfulPageEdits) {
             window.alert("Could not prepare the edited PDF for download. Please try again.");
             return;
         }
@@ -278,6 +289,13 @@ export async function downloadPdfFile({ fileUrl, fileName, pageEdits }: Download
         document.body.appendChild(fallbackLink);
         fallbackLink.click();
         fallbackLink.remove();
+        return;
+    }
+
+    try {
+        await saveBlob(blob, ensurePdfFileName(fileName));
+    } catch {
+        window.alert("Could not save the PDF for download. Please try again.");
     }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,16 +5,12 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  dompurify@>=3.1.3 <=3.3.1: '>=3.3.2'
-  minimatch@<3.1.3: '>=3.1.3'
-  minimatch@<3.1.4: '>=3.1.4'
-  pdfjs-dist@<=4.1.392: '>=4.2.67'
-  tar@<7.5.7: '>=7.5.7'
-  tar@<7.5.8: '>=7.5.8'
-  tar@<=7.5.10: '>=7.5.11'
-  tar@<=7.5.2: '>=7.5.3'
-  tar@<=7.5.3: '>=7.5.4'
-  tar@<=7.5.9: '>=7.5.10'
+  fast-uri: 3.1.2
+  fast-xml-builder: 1.1.7
+  hono: 4.12.16
+  ip-address: 10.1.1
+  postcss: 8.5.13
+  uuid: 14.0.0
 
 importers:
 
@@ -256,8 +252,8 @@ importers:
         specifier: 1.0.0-rc.1
         version: 1.0.0-rc.1
       postcss:
-        specifier: ^8.5.15
-        version: 8.5.15
+        specifier: 8.5.13
+        version: 8.5.13
       tailwindcss:
         specifier: ^4.3.1
         version: 4.3.1
@@ -270,27 +266,6 @@ importers:
       wrangler:
         specifier: ^4.104.0
         version: 4.104.0(@cloudflare/workers-types@4.20260624.1)
-
-  packages/capacitor-native-tab:
-    devDependencies:
-      '@capacitor/android':
-        specifier: ^8.4.1
-        version: 8.4.1(@capacitor/core@8.4.1)
-      '@capacitor/core':
-        specifier: ^8.4.1
-        version: 8.4.1
-      '@capacitor/ios':
-        specifier: ^8.4.1
-        version: 8.4.1(@capacitor/core@8.4.1)
-      rimraf:
-        specifier: ^6.1.3
-        version: 6.1.3
-      rollup:
-        specifier: ^4.62.2
-        version: 4.62.2
-      typescript:
-        specifier: ^6.0.3
-        version: 6.0.3
 
   packages/cli:
     dependencies:
@@ -1122,7 +1097,7 @@ packages:
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: ^4
+      hono: 4.12.16
 
   '@iconify/types@2.0.0':
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
@@ -2042,144 +2017,6 @@ packages:
 
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
-
-  '@rollup/rollup-android-arm-eabi@4.62.2':
-    resolution: {integrity: sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==}
-    cpu: [arm]
-    os: [android]
-
-  '@rollup/rollup-android-arm64@4.62.2':
-    resolution: {integrity: sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==}
-    cpu: [arm64]
-    os: [android]
-
-  '@rollup/rollup-darwin-arm64@4.62.2':
-    resolution: {integrity: sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@rollup/rollup-darwin-x64@4.62.2':
-    resolution: {integrity: sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@rollup/rollup-freebsd-arm64@4.62.2':
-    resolution: {integrity: sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==}
-    cpu: [arm64]
-    os: [freebsd]
-
-  '@rollup/rollup-freebsd-x64@4.62.2':
-    resolution: {integrity: sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
-    resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
-    cpu: [arm]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
-    resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
-    cpu: [arm]
-    os: [linux]
-    libc: [musl]
-
-  '@rollup/rollup-linux-arm64-gnu@4.62.2':
-    resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-arm64-musl@4.62.2':
-    resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@rollup/rollup-linux-loong64-gnu@4.62.2':
-    resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
-    cpu: [loong64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-loong64-musl@4.62.2':
-    resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
-    cpu: [loong64]
-    os: [linux]
-    libc: [musl]
-
-  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
-    resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-ppc64-musl@4.62.2':
-    resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [musl]
-
-  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
-    resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-riscv64-musl@4.62.2':
-    resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [musl]
-
-  '@rollup/rollup-linux-s390x-gnu@4.62.2':
-    resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-x64-gnu@4.62.2':
-    resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-x64-musl@4.62.2':
-    resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@rollup/rollup-openbsd-x64@4.62.2':
-    resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
-    cpu: [x64]
-    os: [openbsd]
-
-  '@rollup/rollup-openharmony-arm64@4.62.2':
-    resolution: {integrity: sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@rollup/rollup-win32-arm64-msvc@4.62.2':
-    resolution: {integrity: sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@rollup/rollup-win32-ia32-msvc@4.62.2':
-    resolution: {integrity: sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==}
-    cpu: [ia32]
-    os: [win32]
-
-  '@rollup/rollup-win32-x64-gnu@4.62.2':
-    resolution: {integrity: sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==}
-    cpu: [x64]
-    os: [win32]
-
-  '@rollup/rollup-win32-x64-msvc@4.62.2':
-    resolution: {integrity: sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==}
-    cpu: [x64]
-    os: [win32]
 
   '@shikijs/core@3.23.0':
     resolution: {integrity: sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==}
@@ -3460,9 +3297,6 @@ packages:
   fast-xml-builder@1.1.7:
     resolution: {integrity: sha512-Yh7/7rQuMXICNr0oMYDR2yHP6oUvmQsTToFeOWj/kIDhAwQ+c4Ol/lbcwOmEM5OHYQmh6S6EQSQ1sljCKP36bQ==}
 
-  fast-xml-builder@1.2.0:
-    resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
-
   fast-xml-parser@5.7.1:
     resolution: {integrity: sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==}
     hasBin: true
@@ -3700,8 +3534,8 @@ packages:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
 
-  ip-address@10.1.0:
-    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+  ip-address@10.1.1:
+    resolution: {integrity: sha512-1FMu8/N15Ck1BL551Jf42NYIoin2unWjLQ2Fze/DXryJRl5twqtwNHlO39qERGbIOcKYWHdgRryhOC+NG4eaLw==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -4464,12 +4298,8 @@ packages:
   points-on-path@0.2.1:
     resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
 
-  postcss@8.5.10:
-    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
-    engines: {node: ^10 || ^12 || >=14}
-
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+  postcss@8.5.13:
+    resolution: {integrity: sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==}
     engines: {node: ^10 || ^12 || >=14}
 
   postgres-array@2.0.0:
@@ -4707,11 +4537,6 @@ packages:
   rolldown@1.0.2:
     resolution: {integrity: sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-
-  rollup@4.62.2:
-    resolution: {integrity: sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
   roughjs@4.6.6:
@@ -5096,13 +4921,8 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  uuid@11.1.1:
-    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
-    hasBin: true
-
-  uuid@8.3.2:
-    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
   vary@1.1.2:
@@ -6864,81 +6684,6 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@rollup/rollup-android-arm-eabi@4.62.2':
-    optional: true
-
-  '@rollup/rollup-android-arm64@4.62.2':
-    optional: true
-
-  '@rollup/rollup-darwin-arm64@4.62.2':
-    optional: true
-
-  '@rollup/rollup-darwin-x64@4.62.2':
-    optional: true
-
-  '@rollup/rollup-freebsd-arm64@4.62.2':
-    optional: true
-
-  '@rollup/rollup-freebsd-x64@4.62.2':
-    optional: true
-
-  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
-    optional: true
-
-  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
-    optional: true
-
-  '@rollup/rollup-linux-arm64-gnu@4.62.2':
-    optional: true
-
-  '@rollup/rollup-linux-arm64-musl@4.62.2':
-    optional: true
-
-  '@rollup/rollup-linux-loong64-gnu@4.62.2':
-    optional: true
-
-  '@rollup/rollup-linux-loong64-musl@4.62.2':
-    optional: true
-
-  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
-    optional: true
-
-  '@rollup/rollup-linux-ppc64-musl@4.62.2':
-    optional: true
-
-  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
-    optional: true
-
-  '@rollup/rollup-linux-riscv64-musl@4.62.2':
-    optional: true
-
-  '@rollup/rollup-linux-s390x-gnu@4.62.2':
-    optional: true
-
-  '@rollup/rollup-linux-x64-gnu@4.62.2':
-    optional: true
-
-  '@rollup/rollup-linux-x64-musl@4.62.2':
-    optional: true
-
-  '@rollup/rollup-openbsd-x64@4.62.2':
-    optional: true
-
-  '@rollup/rollup-openharmony-arm64@4.62.2':
-    optional: true
-
-  '@rollup/rollup-win32-arm64-msvc@4.62.2':
-    optional: true
-
-  '@rollup/rollup-win32-ia32-msvc@4.62.2':
-    optional: true
-
-  '@rollup/rollup-win32-x64-gnu@4.62.2':
-    optional: true
-
-  '@rollup/rollup-win32-x64-msvc@4.62.2':
-    optional: true
-
   '@shikijs/core@3.23.0':
     dependencies:
       '@shikijs/types': 3.23.0
@@ -7125,7 +6870,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.3.1
       '@tailwindcss/oxide': 4.3.1
-      postcss: 8.5.15
+      postcss: 8.5.13
       tailwindcss: 4.3.1
 
   '@tokenizer/inflate@0.4.1':
@@ -7403,7 +7148,7 @@ snapshots:
       '@vue/shared': 3.5.34
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.15
+      postcss: 8.5.13
       source-map-js: 1.2.1
 
   '@vue/compiler-ssr@3.5.34':
@@ -8139,7 +7884,7 @@ snapshots:
   express-rate-limit@8.4.1(express@5.2.1):
     dependencies:
       express: 5.2.1
-      ip-address: 10.1.0
+      ip-address: 10.1.1
 
   express@5.2.1:
     dependencies:
@@ -8194,11 +7939,6 @@ snapshots:
     dependencies:
       path-expression-matcher: 1.5.0
 
-  fast-xml-builder@1.2.0:
-    dependencies:
-      path-expression-matcher: 1.5.0
-      xml-naming: 0.1.0
-
   fast-xml-parser@5.7.1:
     dependencies:
       '@nodable/entities': 2.1.0
@@ -8209,7 +7949,7 @@ snapshots:
   fast-xml-parser@5.9.3:
     dependencies:
       '@nodable/entities': 2.2.0
-      fast-xml-builder: 1.2.0
+      fast-xml-builder: 1.1.7
       is-unsafe: 1.0.1
       path-expression-matcher: 1.5.0
       strnum: 2.4.1
@@ -8528,7 +8268,7 @@ snapshots:
 
   internmap@2.0.3: {}
 
-  ip-address@10.1.0: {}
+  ip-address@10.1.1: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -8553,7 +8293,7 @@ snapshots:
 
   is-reference@3.0.3:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
 
   is-unsafe@1.0.1: {}
 
@@ -8939,7 +8679,7 @@ snapshots:
       roughjs: 4.6.6
       stylis: 4.4.0
       ts-dedent: 2.2.0
-      uuid: 11.1.1
+      uuid: 14.0.0
 
   meshoptimizer@1.1.1: {}
 
@@ -9272,7 +9012,7 @@ snapshots:
       preact-render-to-string: 5.2.6(preact@10.28.3)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      uuid: 8.3.2
+      uuid: 14.0.0
 
   next@16.3.0-preview.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
@@ -9280,7 +9020,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.31
       caniuse-lite: 1.0.30001793
-      postcss: 8.5.10
+      postcss: 8.5.13
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.7)
@@ -9489,13 +9229,7 @@ snapshots:
       path-data-parser: 0.1.0
       points-on-curve: 0.2.0
 
-  postcss@8.5.10:
-    dependencies:
-      nanoid: 3.3.12
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.5.15:
+  postcss@8.5.13:
     dependencies:
       nanoid: 3.3.12
       picocolors: 1.1.1
@@ -9820,37 +9554,6 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.2
       '@rolldown/binding-win32-x64-msvc': 1.0.2
 
-  rollup@4.62.2:
-    dependencies:
-      '@types/estree': 1.0.9
-    optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.62.2
-      '@rollup/rollup-android-arm64': 4.62.2
-      '@rollup/rollup-darwin-arm64': 4.62.2
-      '@rollup/rollup-darwin-x64': 4.62.2
-      '@rollup/rollup-freebsd-arm64': 4.62.2
-      '@rollup/rollup-freebsd-x64': 4.62.2
-      '@rollup/rollup-linux-arm-gnueabihf': 4.62.2
-      '@rollup/rollup-linux-arm-musleabihf': 4.62.2
-      '@rollup/rollup-linux-arm64-gnu': 4.62.2
-      '@rollup/rollup-linux-arm64-musl': 4.62.2
-      '@rollup/rollup-linux-loong64-gnu': 4.62.2
-      '@rollup/rollup-linux-loong64-musl': 4.62.2
-      '@rollup/rollup-linux-ppc64-gnu': 4.62.2
-      '@rollup/rollup-linux-ppc64-musl': 4.62.2
-      '@rollup/rollup-linux-riscv64-gnu': 4.62.2
-      '@rollup/rollup-linux-riscv64-musl': 4.62.2
-      '@rollup/rollup-linux-s390x-gnu': 4.62.2
-      '@rollup/rollup-linux-x64-gnu': 4.62.2
-      '@rollup/rollup-linux-x64-musl': 4.62.2
-      '@rollup/rollup-openbsd-x64': 4.62.2
-      '@rollup/rollup-openharmony-arm64': 4.62.2
-      '@rollup/rollup-win32-arm64-msvc': 4.62.2
-      '@rollup/rollup-win32-ia32-msvc': 4.62.2
-      '@rollup/rollup-win32-x64-gnu': 4.62.2
-      '@rollup/rollup-win32-x64-msvc': 4.62.2
-      fsevents: 2.3.3
-
   roughjs@4.6.6:
     dependencies:
       hachure-fill: 0.5.2
@@ -10120,7 +9823,7 @@ snapshots:
       '@jridgewell/remapping': 2.3.5
       '@jridgewell/sourcemap-codec': 1.5.5
       '@sveltejs/acorn-typescript': 1.0.10(acorn@8.17.0)
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       '@types/trusted-types': 2.0.7
       acorn: 8.17.0
       aria-query: 5.3.1
@@ -10314,9 +10017,7 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  uuid@11.1.1: {}
-
-  uuid@8.3.2: {}
+  uuid@14.0.0: {}
 
   vary@1.1.2: {}
 

--- a/scripts/test-global-error-reload-guard.ts
+++ b/scripts/test-global-error-reload-guard.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import {
+  claimChunkReload,
+  clearReloadGuard,
+  getChunkErrorKey,
+  hasFreshReloadGuard,
+  isChunkLoadError,
+} from "../app/global-error-reload-guard";
+
+const RELOAD_FLAG = "examcooker:chunk-reload";
+
+type SessionStorageStub = {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+};
+
+function installWindow(sessionStorage: SessionStorageStub) {
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: { sessionStorage },
+  });
+}
+
+function createMemoryStorage(initialEntries: Record<string, string> = {}): SessionStorageStub {
+  const entries = new Map(Object.entries(initialEntries));
+  return {
+    getItem(key) {
+      return entries.get(key) ?? null;
+    },
+    setItem(key, value) {
+      entries.set(key, value);
+    },
+    removeItem(key) {
+      entries.delete(key);
+    },
+  };
+}
+
+function createThrowingStorage(): SessionStorageStub {
+  return {
+    getItem() {
+      throw new Error("sessionStorage unavailable");
+    },
+    setItem() {
+      throw new Error("sessionStorage unavailable");
+    },
+    removeItem() {
+      throw new Error("sessionStorage unavailable");
+    },
+  };
+}
+
+const realDateNow = Date.now;
+
+try {
+  const now = 1_000_000;
+  Date.now = () => now;
+
+  const chunkError = new Error("Loading chunk app-pages-browser failed");
+  chunkError.name = "ChunkLoadError";
+  const key = getChunkErrorKey(chunkError);
+
+  assert.equal(isChunkLoadError(chunkError), true);
+  assert.equal(isChunkLoadError(new Error("ordinary failure")), false);
+
+  installWindow(createMemoryStorage());
+  assert.equal(claimChunkReload(key), true, "first chunk error claims a guarded reload");
+  assert.equal(hasFreshReloadGuard(key), true, "claim writes a fresh reload guard");
+  assert.equal(claimChunkReload(key), false, "fresh guard blocks repeated reloads");
+
+  installWindow(createMemoryStorage({
+    [RELOAD_FLAG]: JSON.stringify({ key, timestamp: now - 60_001 }),
+  }));
+  assert.equal(claimChunkReload(key), true, "stale guard allows a later reload");
+
+  installWindow(createThrowingStorage());
+  assert.equal(
+    claimChunkReload(key),
+    false,
+    "storage failures must not trigger an unguarded reload loop",
+  );
+  clearReloadGuard();
+
+  console.log("global error reload guard tests passed");
+} finally {
+  Date.now = realDateNow;
+}

--- a/scripts/test-pdf-download-page-edits.ts
+++ b/scripts/test-pdf-download-page-edits.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
+import { Capacitor } from "@capacitor/core";
 import { PDFDocument } from "pdf-lib";
-import { preparePdfDownloadBlob } from "../lib/downloads/browser-downloads";
+import {
+  downloadPdfFile,
+  preparePdfDownloadBlob,
+} from "../lib/downloads/browser-downloads";
 import type { PdfPageEdits } from "../lib/pdf/page-edits";
 
 async function createSourcePdf() {
@@ -31,11 +35,18 @@ async function main() {
   const sourceBlob = new Blob([toArrayBuffer(sourceBytes)], {
     type: "application/pdf",
   });
+  const globalAny = globalThis as any;
 
   assert.equal(
     await preparePdfDownloadBlob(sourceBlob, null),
     sourceBlob,
     "Unedited PDFs should keep the original download blob",
+  );
+
+  assert.equal(
+    await preparePdfDownloadBlob(sourceBlob, { pageOrder: [], pageRotations: {} }),
+    sourceBlob,
+    "No-op edits should keep the original download blob",
   );
 
   const editedBlob = await preparePdfDownloadBlob(sourceBlob, pageEdits);
@@ -54,6 +65,169 @@ async function main() {
   const thirdPage = editedDocument.getPage(2);
   assert.equal(thirdPage.getWidth(), 400);
   assert.equal(thirdPage.getRotation().angle, 0);
+
+  const originalFetch = globalThis.fetch;
+  const originalWindow = globalAny.window;
+  const originalDocument = globalAny.document;
+  const nativePlatformDescriptor = Object.getOwnPropertyDescriptor(
+    Capacitor,
+    "isNativePlatform",
+  );
+  const nativePromiseDescriptor = Object.getOwnPropertyDescriptor(
+    Capacitor,
+    "nativePromise",
+  );
+
+  const clickedAnchors: Array<{
+    href: string;
+    download: string;
+    target: string;
+    rel: string;
+  }> = [];
+  const alerts: string[] = [];
+  const createdObjectUrls: string[] = [];
+  let objectUrlCount = 0;
+
+  const createAnchor = () => {
+    const anchor = {
+      href: "",
+      download: "",
+      target: "",
+      rel: "",
+      click() {
+        clickedAnchors.push({
+          href: anchor.href,
+          download: anchor.download,
+          target: anchor.target,
+          rel: anchor.rel,
+        });
+      },
+      remove() {
+        return;
+      },
+    };
+
+    return anchor;
+  };
+
+  const windowMock = {
+    URL: {
+      createObjectURL() {
+        objectUrlCount += 1;
+        const next = `blob:mock-${objectUrlCount}`;
+        createdObjectUrls.push(next);
+        return next;
+      },
+      revokeObjectURL() {
+        return;
+      },
+    },
+    setTimeout(callback: () => void) {
+      callback();
+      return 1;
+    },
+    clearTimeout() {
+      return;
+    },
+    alert(message: string) {
+      alerts.push(message);
+    },
+    btoa(input: string) {
+      return Buffer.from(input, "binary").toString("base64");
+    },
+  };
+  const documentMock = {
+    body: {
+      appendChild() {
+        return;
+      },
+    },
+    createElement(tagName: string) {
+      if (tagName !== "a") {
+        throw new Error(`Unexpected element request: ${tagName}`);
+      }
+      return createAnchor();
+    },
+  };
+
+  globalAny.window = windowMock;
+  globalAny.document = documentMock;
+
+  try {
+    Object.defineProperty(Capacitor, "isNativePlatform", {
+      configurable: true,
+      value: () => false,
+    });
+    globalThis.fetch = async () => {
+      throw new Error("network down");
+    };
+
+    await downloadPdfFile({
+      fileUrl: "https://example.com/original.pdf",
+      fileName: "fallback.pdf",
+      pageEdits: { pageOrder: [], pageRotations: {} },
+    });
+
+    assert.equal(alerts.length, 0, "No-op edits should not show preparation alert");
+    assert.deepEqual(clickedAnchors.pop(), {
+      href: "https://example.com/original.pdf",
+      download: "",
+      target: "_blank",
+      rel: "noopener noreferrer",
+    });
+
+    Object.defineProperty(Capacitor, "isNativePlatform", {
+      configurable: true,
+      value: () => true,
+    });
+    Object.defineProperty(Capacitor, "nativePromise", {
+      configurable: true,
+      value: async () => {
+        throw new Error("native save failed");
+      },
+    });
+    globalThis.fetch = async () =>
+      new Response(sourceBlob, {
+        status: 200,
+      });
+
+    await downloadPdfFile({
+      fileUrl: "https://example.com/edited.pdf",
+      fileName: "edited.pdf",
+      pageEdits,
+    });
+
+    assert.equal(alerts.length, 0, "Native save failures should not surface as prep alerts");
+    assert.equal(createdObjectUrls.length, 1, "Native save failure should fall back to blob URL");
+    assert.deepEqual(clickedAnchors.pop(), {
+      href: "blob:mock-1",
+      download: "edited.pdf",
+      target: "",
+      rel: "",
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+
+    if (typeof originalWindow === "undefined") {
+      delete globalAny.window;
+    } else {
+      globalAny.window = originalWindow;
+    }
+
+    if (typeof originalDocument === "undefined") {
+      delete globalAny.document;
+    } else {
+      globalAny.document = originalDocument;
+    }
+
+    if (nativePlatformDescriptor) {
+      Object.defineProperty(Capacitor, "isNativePlatform", nativePlatformDescriptor);
+    }
+
+    if (nativePromiseDescriptor) {
+      Object.defineProperty(Capacitor, "nativePromise", nativePromiseDescriptor);
+    }
+  }
 
   console.log("PDF download page edits are preserved.");
 }

--- a/scripts/test-pdf-download-page-edits.ts
+++ b/scripts/test-pdf-download-page-edits.ts
@@ -20,30 +20,34 @@ const pageEdits: PdfPageEdits = {
   },
 };
 
-const sourceBytes = await createSourcePdf();
-const sourceBlob = new Blob([sourceBytes], { type: "application/pdf" });
+async function main() {
+  const sourceBytes = await createSourcePdf();
+  const sourceBlob = new Blob([sourceBytes], { type: "application/pdf" });
 
-assert.equal(
-  await preparePdfDownloadBlob(sourceBlob, null),
-  sourceBlob,
-  "Unedited PDFs should keep the original download blob",
-);
+  assert.equal(
+    await preparePdfDownloadBlob(sourceBlob, null),
+    sourceBlob,
+    "Unedited PDFs should keep the original download blob",
+  );
 
-const editedBlob = await preparePdfDownloadBlob(sourceBlob, pageEdits);
-const editedDocument = await PDFDocument.load(await editedBlob.arrayBuffer());
+  const editedBlob = await preparePdfDownloadBlob(sourceBlob, pageEdits);
+  const editedDocument = await PDFDocument.load(await editedBlob.arrayBuffer());
 
-assert.equal(editedDocument.getPageCount(), 3);
+  assert.equal(editedDocument.getPageCount(), 3);
 
-const firstPage = editedDocument.getPage(0);
-assert.equal(firstPage.getWidth(), 600);
-assert.equal(firstPage.getRotation().angle, 180);
+  const firstPage = editedDocument.getPage(0);
+  assert.equal(firstPage.getWidth(), 600);
+  assert.equal(firstPage.getRotation().angle, 180);
 
-const secondPage = editedDocument.getPage(1);
-assert.equal(secondPage.getWidth(), 200);
-assert.equal(secondPage.getRotation().angle, 90);
+  const secondPage = editedDocument.getPage(1);
+  assert.equal(secondPage.getWidth(), 200);
+  assert.equal(secondPage.getRotation().angle, 90);
 
-const thirdPage = editedDocument.getPage(2);
-assert.equal(thirdPage.getWidth(), 400);
-assert.equal(thirdPage.getRotation().angle, 0);
+  const thirdPage = editedDocument.getPage(2);
+  assert.equal(thirdPage.getWidth(), 400);
+  assert.equal(thirdPage.getRotation().angle, 0);
 
-console.log("PDF download page edits are preserved.");
+  console.log("PDF download page edits are preserved.");
+}
+
+void main();

--- a/scripts/test-pdf-download-page-edits.ts
+++ b/scripts/test-pdf-download-page-edits.ts
@@ -12,6 +12,12 @@ async function createSourcePdf() {
   return document.save();
 }
 
+function toArrayBuffer(bytes: Uint8Array) {
+  const copy = new Uint8Array(bytes.byteLength);
+  copy.set(bytes);
+  return copy.buffer;
+}
+
 const pageEdits: PdfPageEdits = {
   pageOrder: [2, 0, 1],
   pageRotations: {
@@ -22,7 +28,9 @@ const pageEdits: PdfPageEdits = {
 
 async function main() {
   const sourceBytes = await createSourcePdf();
-  const sourceBlob = new Blob([sourceBytes], { type: "application/pdf" });
+  const sourceBlob = new Blob([toArrayBuffer(sourceBytes)], {
+    type: "application/pdf",
+  });
 
   assert.equal(
     await preparePdfDownloadBlob(sourceBlob, null),

--- a/scripts/test-pdf-download-page-edits.ts
+++ b/scripts/test-pdf-download-page-edits.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { PDFDocument } from "pdf-lib";
+import { preparePdfDownloadBlob } from "../lib/downloads/browser-downloads";
+import type { PdfPageEdits } from "../lib/pdf/page-edits";
+
+async function createSourcePdf() {
+  const document = await PDFDocument.create();
+  document.addPage([200, 300]);
+  document.addPage([400, 300]);
+  document.addPage([600, 300]);
+
+  return document.save();
+}
+
+const pageEdits: PdfPageEdits = {
+  pageOrder: [2, 0, 1],
+  pageRotations: {
+    "2": 180,
+    "0": 90,
+  },
+};
+
+const sourceBytes = await createSourcePdf();
+const sourceBlob = new Blob([sourceBytes], { type: "application/pdf" });
+
+assert.equal(
+  await preparePdfDownloadBlob(sourceBlob, null),
+  sourceBlob,
+  "Unedited PDFs should keep the original download blob",
+);
+
+const editedBlob = await preparePdfDownloadBlob(sourceBlob, pageEdits);
+const editedDocument = await PDFDocument.load(await editedBlob.arrayBuffer());
+
+assert.equal(editedDocument.getPageCount(), 3);
+
+const firstPage = editedDocument.getPage(0);
+assert.equal(firstPage.getWidth(), 600);
+assert.equal(firstPage.getRotation().angle, 180);
+
+const secondPage = editedDocument.getPage(1);
+assert.equal(secondPage.getWidth(), 200);
+assert.equal(secondPage.getRotation().angle, 90);
+
+const thirdPage = editedDocument.getPage(2);
+assert.equal(thirdPage.getWidth(), 400);
+assert.equal(thirdPage.getRotation().angle, 0);
+
+console.log("PDF download page edits are preserved.");


### PR DESCRIPTION
<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR improves PDF viewing and downloads, navigation stability, and global error recovery. The main changes are:

- Replaces rendered-page data URLs with managed object URLs.
- Preserves page ordering and rotation edits in PDF downloads.
- Adds browser fallback when native PDF saving fails.
- Guards reloads caused by stale JavaScript or CSS chunks.
- Makes experimental page transitions opt-in.
- Adds focused scripts for reload guards and edited downloads.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

The rendered-page object URLs are released on replacement, stale completion, and unmount.

No blocking issues remain in the updated fix.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Observed that the pdf-flow run produced HTTP 500 responses for both the grid route and the PDF detail route, indicating a pre-render failure.
- Validated the Next.js startup output showed the shared blocker DATABASE\_URL is not set.
- Ran and reviewed the test harness, including the two TypeScript tests; both exited with code 0 and printed their success messages.

<a href="https://app.greptile.com/trex/runs/14150601/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| app/components/pdfviewer.tsx | Uses object URLs for rendered PDF pages and cleans them up on replacement, stale completion, and unmount. |
| lib/downloads/browser-downloads.ts | Applies page edits to downloaded PDFs and adds a browser fallback for native save failures. |
| app/global-error.tsx | Uses a shared reload guard to prevent repeated reloads after chunk-loading failures. |
| app/components/common/directional-transition.tsx | Makes experimental page view transitions opt-in through a public environment flag. |

<sub>Reviews (2): Last reviewed commit: ["fix: avoid base64 page state in pdf view..."](https://github.com/acm-vit/examcooker/commit/2a1af0270f2d108737c4f4a8a0f14f293947e751) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43623551)</sub>

<!-- /greptile_comment -->