### PR TITLE
Dev

### DIFF
--- a/.github/workflows/deploy-appservice.yml
+++ b/.github/workflows/deploy-appservice.yml
@@ -35,6 +35,11 @@ jobs:
       NEXT_PUBLIC_POSTHOG_KEY: ${{ secrets.NEXT_PUBLIC_POSTHOG_KEY }}
       NEXT_PUBLIC_POSTHOG_HOST: ${{ vars.NEXT_PUBLIC_POSTHOG_HOST }}
       NEXT_PUBLIC_POSTHOG_PROXY_PATH: ${{ vars.NEXT_PUBLIC_POSTHOG_PROXY_PATH }}
+      # Source-map upload is opt-in: it only runs once POSTHOG_CLI_TOKEN (a
+      # personal API key) and the POSTHOG_CLI_ENV_ID project id are configured.
+      # Until then this evaluates to "false" and the build behaves exactly as
+      # before (no source maps emitted, no upload step).
+      POSTHOG_SOURCEMAP_UPLOAD: ${{ secrets.POSTHOG_CLI_TOKEN != '' && vars.POSTHOG_CLI_ENV_ID != '' }}
 
     steps:
       - name: Checkout
@@ -75,6 +80,25 @@ jobs:
       - name: Build application
         working-directory: ${{ env.BUILD_DIR }}
         run: npm run build
+
+      # Symbolicate client stack traces in PostHog error tracking. Injects a chunk
+      # id into each built JS chunk, uploads the matching source maps, then strips
+      # the `.map` files so they are never served publicly. Gated on the CLI
+      # secrets and best-effort (continue-on-error) so it can never block a deploy.
+      - name: Upload source maps to PostHog
+        if: ${{ env.POSTHOG_SOURCEMAP_UPLOAD == 'true' }}
+        continue-on-error: true
+        working-directory: ${{ env.BUILD_DIR }}
+        env:
+          POSTHOG_CLI_TOKEN: ${{ secrets.POSTHOG_CLI_TOKEN }}
+          POSTHOG_CLI_ENV_ID: ${{ vars.POSTHOG_CLI_ENV_ID }}
+          # PostHog region host for the CLI; defaults to EU to match this project.
+          POSTHOG_CLI_HOST: ${{ vars.POSTHOG_CLI_HOST || 'https://eu.posthog.com' }}
+        run: |
+          set -eux
+          npx --yes @posthog/cli@latest --host "${POSTHOG_CLI_HOST}" sourcemap inject --directory .next/static
+          npx --yes @posthog/cli@latest --host "${POSTHOG_CLI_HOST}" sourcemap upload --directory .next/static
+          find .next/static -name '*.map' -type f -delete
 
       - name: Package deployment payload
         run: |

--- a/app/(app)/home/pixel-bg.tsx
+++ b/app/(app)/home/pixel-bg.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Effect, EffectComposer, EffectPass, RenderPass } from 'postprocessing';
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import * as THREE from 'three';
 
 type PixelBlastVariant = 'square' | 'circle' | 'triangle' | 'diamond';
@@ -425,6 +425,7 @@ const PixelBlast: React.FC<PixelBlastProps> = ({
     resizeObserver?: ResizeObserver;
     raf?: number;
     cleanupPointerEvents?: () => void;
+    cleanupContextEvents?: () => void;
     quad?: THREE.Mesh<THREE.PlaneGeometry, THREE.ShaderMaterial>;
     timeOffset?: number;
     composer?: EffectComposer;
@@ -432,6 +433,9 @@ const PixelBlast: React.FC<PixelBlastProps> = ({
     liquidEffect?: Effect;
   } | null>(null);
   const prevConfigRef = useRef<ReinitConfig | null>(null);
+  // Bumped when the WebGL context is restored so the setup effect re-runs and
+  // rebuilds the renderer from scratch instead of drawing into a dead context.
+  const [reinitToken, setReinitToken] = useState(0);
 
   useEffect(() => {
     if (!autoPauseOffscreen) {
@@ -484,6 +488,7 @@ const PixelBlast: React.FC<PixelBlastProps> = ({
       if (threeRef.current) {
         const t = threeRef.current;
         t.cleanupPointerEvents?.();
+        t.cleanupContextEvents?.();
         t.resizeObserver?.disconnect();
         cancelAnimationFrame(t.raf!);
         t.quad?.geometry.dispose();
@@ -635,8 +640,29 @@ const PixelBlast: React.FC<PixelBlastProps> = ({
         onPointerDown,
         onPointerMove,
       );
+      const onContextLost = (event: Event) => {
+        // preventDefault lets the browser attempt to restore the context and
+        // fire webglcontextrestored; also stop the render loop immediately.
+        event.preventDefault();
+        if (threeRef.current?.raf != null) cancelAnimationFrame(threeRef.current.raf);
+        cancelAnimationFrame(raf);
+      };
+      const onContextRestored = () => {
+        // Rebuild the renderer from scratch on the next effect run.
+        setReinitToken(n => n + 1);
+      };
+      renderer.domElement.addEventListener('webglcontextlost', onContextLost, false);
+      renderer.domElement.addEventListener('webglcontextrestored', onContextRestored, false);
+      const cleanupContextEvents = () => {
+        renderer.domElement.removeEventListener('webglcontextlost', onContextLost, false);
+        renderer.domElement.removeEventListener('webglcontextrestored', onContextRestored, false);
+      };
       let raf = 0;
       const animate = () => {
+        // Never feed draw calls into a lost context: Three.js would try to
+        // re-acquire the program and pass a null shader into gl.shaderSource().
+        // The loop is restarted by the webglcontextrestored handler below.
+        if (renderer.getContext().isContextLost()) return;
         if (autoPauseOffscreen && !visibilityRef.current.visible) {
           raf = requestAnimationFrame(animate);
           return;
@@ -674,6 +700,7 @@ const PixelBlast: React.FC<PixelBlastProps> = ({
         resizeObserver: ro,
         raf,
         cleanupPointerEvents,
+        cleanupContextEvents,
         quad,
         timeOffset,
         composer,
@@ -709,6 +736,7 @@ const PixelBlast: React.FC<PixelBlastProps> = ({
       if (!threeRef.current) return;
       const t = threeRef.current;
       t.cleanupPointerEvents?.();
+      t.cleanupContextEvents?.();
       t.resizeObserver?.disconnect();
       cancelAnimationFrame(t.raf!);
       t.quad?.geometry.dispose();
@@ -739,7 +767,8 @@ const PixelBlast: React.FC<PixelBlastProps> = ({
     autoPauseOffscreen,
     variant,
     color,
-    speed
+    speed,
+    reinitToken
   ]);
 
   return (

--- a/app/api/account/delete/route.ts
+++ b/app/api/account/delete/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
 import { eq, sql } from "drizzle-orm";
 import { auth } from "@/app/auth";
 import { type Database, db } from "@/db";
@@ -18,6 +19,13 @@ import {
   viewHistory,
   vote,
 } from "@/db/schema";
+
+const SESSION_COOKIE_BASE_NAMES = [
+  "authjs.session-token",
+  "__Secure-authjs.session-token",
+  "next-auth.session-token",
+  "__Secure-next-auth.session-token",
+];
 
 async function tableExists(tableName: string) {
   const result = await db.execute<{ exists: boolean }>(sql`
@@ -98,7 +106,32 @@ export async function POST() {
       .where(eq(user.id, userId));
   });
 
-  return NextResponse.json({ ok: true });
+  const response = NextResponse.json({ ok: true });
+  const cookieStore = await cookies();
+  const sessionCookieNames = new Set(SESSION_COOKIE_BASE_NAMES);
+
+  for (const cookie of cookieStore.getAll()) {
+    if (
+      SESSION_COOKIE_BASE_NAMES.some(
+        (baseName) =>
+          cookie.name === baseName || cookie.name.startsWith(`${baseName}.`),
+      )
+    ) {
+      sessionCookieNames.add(cookie.name);
+    }
+  }
+
+  for (const name of sessionCookieNames) {
+    response.cookies.set(name, "", {
+      httpOnly: true,
+      maxAge: 0,
+      path: "/",
+      sameSite: "lax",
+      secure: name.startsWith("__Secure-"),
+    });
+  }
+
+  return response;
 }
 
 async function deleteCliAccess(

--- a/app/auth.ts
+++ b/app/auth.ts
@@ -22,6 +22,7 @@ import { createPostHogServer } from "@/lib/posthog-server";
 
 const adapter = createAuthAdapter();
 const ROLE_REFRESH_INTERVAL_SECONDS = 5 * 60;
+const DELETED_ACCOUNT_EMAIL_DOMAIN = "@deleted.examcooker.local";
 const useSecureAuthCookies =
   (process.env.NEXTAUTH_URL ?? process.env.NEXT_PUBLIC_BASE_URL ?? "").startsWith(
     "https://",
@@ -53,6 +54,17 @@ type SessionCallbackParams = {
   session: Session;
   token: AuthToken;
 };
+
+class DeletedAccountSessionError extends Error {
+  constructor() {
+    super("Session user has been deleted");
+    this.name = "DeletedAccountSessionError";
+  }
+}
+
+function isDeletedAccountEmail(email: string | null | undefined) {
+  return email?.endsWith(DELETED_ACCOUNT_EMAIL_DOMAIN) ?? false;
+}
 
 function requiredEnv(name: "AUTH_GOOGLE_ID" | "AUTH_GOOGLE_SECRET") {
   const value = process.env[name];
@@ -452,22 +464,31 @@ export const authConfig = {
         return token;
       }
 
-      const lastSyncedAt = Number(token.roleSyncedAt ?? 0);
       const userId = typeof token.id === "string" ? token.id : null;
-      if (
-        userId &&
-        (!lastSyncedAt || now - lastSyncedAt > ROLE_REFRESH_INTERVAL_SECONDS)
-      ) {
+      if (userId) {
+        const lastSyncedAt = Number(token.roleSyncedAt ?? 0);
+        const shouldRefreshRole =
+          !lastSyncedAt || now - lastSyncedAt > ROLE_REFRESH_INTERVAL_SECONDS;
+
         try {
           const dbUsers = await db
-            .select({ role: userTable.role })
+            .select({ email: userTable.email, role: userTable.role })
             .from(userTable)
             .where(eq(userTable.id, userId));
           const dbUser = dbUsers[0] ?? null;
 
-          if (dbUser?.role) token.role = dbUser.role;
-          token.roleSyncedAt = now;
+          if (!dbUser || isDeletedAccountEmail(dbUser.email)) {
+            throw new DeletedAccountSessionError();
+          }
+
+          if (shouldRefreshRole) {
+            if (dbUser.role) token.role = dbUser.role;
+            token.roleSyncedAt = now;
+          }
         } catch (error) {
+          if (error instanceof DeletedAccountSessionError) {
+            throw error;
+          }
           console.error("[auth] role refresh failed", error);
         }
       }

--- a/app/components/common/directional-transition.tsx
+++ b/app/components/common/directional-transition.tsx
@@ -1,17 +1,23 @@
 "use client";
 
 import React, { ViewTransition, useEffect, useState } from "react";
-import { usePathname } from "next/navigation";
+import type { ViewTransitionClass } from "react";
 
-// `<ViewTransition>` is an experimental React API. On interrupted navigations it
-// can read `_retryCache` off a null Offscreen instance and throw an unhandled
-// `TypeError` when `<Suspense>` boundaries are torn down mid-transition (which they
-// are on every app route, since pages nest Suspense inside this keyed transition).
-// Keep it behind an opt-in flag so we can validate the experimental path before
-// enabling it broadly; when disabled we render children directly with no animation.
-function pageViewTransitionsEnabled() {
-    return process.env.NEXT_PUBLIC_ENABLE_VIEW_TRANSITIONS === "true";
-}
+// `<ViewTransition>` is an experimental React API. It used to be keyed on
+// `pathname`, which forced the whole page subtree to remount on every
+// navigation. Because pages stream their content behind nested `<Suspense>`
+// boundaries, interrupting a navigation tore down the exit-side Offscreen
+// instance while a suspended resource was still pending — React's retry path
+// then read `_retryCache` off a null Offscreen `stateNode` and threw an
+// unhandled `TypeError`.
+//
+// The directional animation never depended on that key: the forward / back /
+// lateral direction comes from React transition *types* (`transitionTypes` on
+// `<Link>` and `addTransitionType(...)` on programmatic navigations), which are
+// mapped to CSS classes below. So we keep a single, persistent `<ViewTransition>`
+// (no `key`) that is never remounted, and animate route changes through the
+// `update` path instead of key-driven enter/exit. Suspense boundaries are no
+// longer torn down mid-transition, which removes the crash at its root.
 
 function hasNativeShellAttributes() {
     if (typeof document === "undefined") return false;
@@ -43,33 +49,30 @@ function useDisablePageViewTransitions() {
     return disabled;
 }
 
+// Transition-type → CSS class mappings, shared by the enter (first mount) and
+// update (route-to-route) paths so both play the same directional animation.
+const NAV_TRANSITION_CLASSES: ViewTransitionClass = {
+    "nav-forward": "nav-forward",
+    "nav-back": "nav-back",
+    "nav-lateral": "nav-lateral",
+    default: "none",
+};
+
 export default function DirectionalTransition({
     children,
 }: {
     children: React.ReactNode;
 }) {
-    const pathname = usePathname();
     const disablePageViewTransitions = useDisablePageViewTransitions();
 
-    if (!pageViewTransitionsEnabled() || disablePageViewTransitions) {
+    if (disablePageViewTransitions) {
         return <>{children}</>;
     }
 
     return (
         <ViewTransition
-            key={pathname}
-            enter={{
-                "nav-forward": "nav-forward",
-                "nav-back": "nav-back",
-                "nav-lateral": "nav-lateral-enter",
-                default: "none",
-            }}
-            exit={{
-                "nav-forward": "nav-forward",
-                "nav-back": "nav-back",
-                "nav-lateral": "nav-lateral-exit",
-                default: "none",
-            }}
+            enter={NAV_TRANSITION_CLASSES}
+            update={NAV_TRANSITION_CLASSES}
             default="none"
         >
             {children}

--- a/app/components/pdfviewer.tsx
+++ b/app/components/pdfviewer.tsx
@@ -2,6 +2,7 @@
 
 import { createPluginRegistration } from "@embedpdf/core";
 import { EmbedPDF, useDocumentState } from "@embedpdf/core/react";
+import { PdfErrorCode } from "@embedpdf/models";
 import Image from "next/image";
 import {
   DocumentContent,
@@ -76,7 +77,11 @@ import {
   normalizePdfPageEdits,
   serializePdfPageEdits,
 } from "@/lib/pdf/page-edits";
-import { capturePdfDownloaded, getPostHogSessionId } from "@/lib/posthog/client";
+import {
+  capturePdfDownloaded,
+  capturePdfPageRenderFailed,
+  getPostHogSessionId,
+} from "@/lib/posthog/client";
 import {
   clearActivePdfSnapshot,
   setActivePdfSnapshot,
@@ -93,6 +98,9 @@ const PAGE_INPUT_CLASS =
 const MIN_ZOOM = 0.2;
 const MAX_ZOOM = 3;
 const SLOW_LOAD_NOTICE_MS = 3500;
+// Promote an indefinitely-hung (or empty-blob) page render into the visible,
+// recoverable retry UI instead of leaving a silent blank page.
+const PAGE_RENDER_TIMEOUT_MS = 20000;
 const PDF_DARK_MODE_FILTER =
   "invert(1) hue-rotate(180deg) brightness(0.92) contrast(0.95)";
 const PDF_MARKDOWN_ENDPOINT = "/api/pdf/markdown";
@@ -1155,6 +1163,7 @@ function PageRenderLayer({
     if (!renderProvides || documentState?.status !== "loaded") return;
 
     let isCurrentRender = true;
+    let didSettle = false;
     setHasRenderError(false);
 
     const task = renderProvides.forDocument(documentId).renderPage({
@@ -1166,14 +1175,62 @@ function PageRenderLayer({
       },
     });
 
+    // A render that hangs indefinitely, rejects, or resolves with an empty
+    // blob all leave a silent blank page today. Funnel every one of them into
+    // the same recoverable retry UI and report it so the failure is visible in
+    // analytics instead of only reaching `console.error`.
+    const failRender = (
+      reason: "render_error" | "render_timeout" | "empty_blob",
+      errorMessage?: string | null,
+    ) => {
+      if (!isCurrentRender || didSettle) return;
+      didSettle = true;
+      capturePdfPageRenderFailed({
+        documentId,
+        pageIndex,
+        reason,
+        timeoutMs: reason === "render_timeout" ? PAGE_RENDER_TIMEOUT_MS : undefined,
+        errorMessage,
+      });
+      setHasRenderError(true);
+    };
+
+    const timeoutId = window.setTimeout(() => {
+      if (!isCurrentRender || didSettle) return;
+      console.error("[PDFViewer] Page render timed out", {
+        documentId,
+        pageIndex,
+        timeoutMs: PAGE_RENDER_TIMEOUT_MS,
+      });
+      failRender("render_timeout");
+      // Best-effort: stop the underlying pdfium work so a hung render does not
+      // keep consuming resources after we have given up on it.
+      try {
+        task.abort({
+          code: PdfErrorCode.Cancelled,
+          message: "Page render timed out",
+        });
+      } catch {
+        // Aborting is best-effort; the error UI is already showing.
+      }
+    }, PAGE_RENDER_TIMEOUT_MS);
+
     task
       .toPromise()
       .then((blob) => {
-        const nextImageUrl = blobToObjectUrl(blob);
-        if (!isCurrentRender) {
-          URL.revokeObjectURL(nextImageUrl);
+        if (!isCurrentRender || didSettle) return;
+        // An empty blob paints nothing, so treat it as a recoverable failure
+        // rather than rendering a silent blank page.
+        if (!blob || blob.size === 0) {
+          console.error("[PDFViewer] Page render produced an empty blob", {
+            documentId,
+            pageIndex,
+          });
+          failRender("empty_blob");
           return;
         }
+        didSettle = true;
+        const nextImageUrl = blobToObjectUrl(blob);
         setImageUrl((previousImageUrl) => {
           if (previousImageUrl && previousImageUrl !== nextImageUrl) {
             URL.revokeObjectURL(previousImageUrl);
@@ -1182,17 +1239,29 @@ function PageRenderLayer({
         });
       })
       .catch((renderError) => {
-        if (!isCurrentRender) return;
+        if (!isCurrentRender || didSettle) return;
         console.error("[PDFViewer] Page render failed", {
           documentId,
           pageIndex,
           renderError,
         });
-        setHasRenderError(true);
+        failRender(
+          "render_error",
+          renderError instanceof Error
+            ? renderError.message
+            : typeof renderError === "string"
+              ? renderError
+              : (renderError as { reason?: { message?: string } } | null)?.reason
+                  ?.message,
+        );
+      })
+      .finally(() => {
+        window.clearTimeout(timeoutId);
       });
 
     return () => {
       isCurrentRender = false;
+      window.clearTimeout(timeoutId);
     };
   }, [
     documentId,

--- a/app/components/syllabus/syllabus-grid.tsx
+++ b/app/components/syllabus/syllabus-grid.tsx
@@ -147,6 +147,16 @@ export default function SyllabusGrid({ syllabi }: { syllabi: SyllabusItem[] }) {
         });
     }, [query, syllabi]);
 
+    // Reset the window synchronously whenever the result set changes (e.g. on
+    // search) — doing this during render (rather than in an effect) means the
+    // new results are never committed with a stale, large visibleCount, which
+    // would briefly mount hundreds of rows and recreate the main-thread stall.
+    const [windowedQuery, setWindowedQuery] = useState(query);
+    if (windowedQuery !== query) {
+        setWindowedQuery(query);
+        setVisibleCount(INITIAL_VISIBLE_COUNT);
+    }
+
     // Only render a window of the (possibly huge) result set so the main thread
     // isn't blocked hydrating thousands of rows at once. More rows reveal as the
     // sentinel scrolls into view.
@@ -156,15 +166,18 @@ export default function SyllabusGrid({ syllabi }: { syllabi: SyllabusItem[] }) {
     );
     const hasMore = visibleCount < filtered.length;
 
-    // Reset the window whenever the result set changes (e.g. on search).
-    useEffect(() => {
-        setVisibleCount(INITIAL_VISIBLE_COUNT);
-    }, [query]);
-
     useEffect(() => {
         if (!hasMore) return;
         const sentinel = sentinelRef.current;
         if (!sentinel) return;
+
+        // Environments without IntersectionObserver (older embedded WebViews)
+        // can't lazily reveal rows, so fall back to rendering everything rather
+        // than leaving the catalog truncated at the initial window.
+        if (typeof IntersectionObserver === "undefined") {
+            setVisibleCount(filtered.length);
+            return;
+        }
 
         const observer = new IntersectionObserver(
             (entries) => {
@@ -177,7 +190,7 @@ export default function SyllabusGrid({ syllabi }: { syllabi: SyllabusItem[] }) {
 
         observer.observe(sentinel);
         return () => observer.disconnect();
-    }, [hasMore, visible.length]);
+    }, [hasMore, visible.length, filtered.length]);
 
     const clear = () => {
         setQuery("");

--- a/app/components/syllabus/syllabus-grid.tsx
+++ b/app/components/syllabus/syllabus-grid.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import React, { useCallback, useRef, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useRef, useMemo, useState } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import Image from "@/app/components/common/app-image";
 import SearchIcon from "@/app/components/assets/seacrh.svg";
 import { useToast } from "@/app/components/ui/use-toast";
@@ -30,16 +31,18 @@ function getSyllabusFileName(syllabus: SyllabusItem) {
     });
 }
 
-function SyllabusRow({
+const SyllabusRow = React.memo(function SyllabusRow({
     syllabus,
     selected,
     onToggleSelect,
     onDownload,
+    onPrefetch,
 }: {
     syllabus: SyllabusItem;
     selected: boolean;
     onToggleSelect: (id: string) => void;
     onDownload: (id: string) => void;
+    onPrefetch: (href: string) => void;
 }) {
     const parsed = parseSyllabusName(syllabus.name);
     const displayName = parsed.courseName || formatSyllabusDisplayName(syllabus.name);
@@ -47,6 +50,8 @@ function SyllabusRow({
     const href = parsed.courseCode
         ? getCourseSyllabusPath(parsed.courseCode)
         : `/syllabus/${syllabus.id}`;
+
+    const handlePrefetch = () => onPrefetch(href);
 
     const handleToggleSelect = (e: React.MouseEvent) => {
         e.stopPropagation();
@@ -63,8 +68,10 @@ function SyllabusRow({
     return (
         <Link
             href={href}
-            prefetch
+            prefetch={false}
             transitionTypes={["nav-forward"]}
+            onPointerEnter={handlePrefetch}
+            onFocus={handlePrefetch}
             className={`ec-press group flex min-w-0 items-center gap-3 border-2 px-3 py-2.5 transition-[background-color,border-color,transform] duration-200 hover:border-b-white hover:bg-[#5FC4E7]/10 dark:hover:border-b-[#3BF4C7] dark:hover:bg-[#ffffff]/10 ${selected
                     ? "border-black bg-[#5FC4E7] dark:border-[#3BF4C7] dark:bg-[#0C1222]"
                     : "border-[#5FC4E7] bg-white dark:border-[#ffffff]/20 dark:bg-[#0C1222]"
@@ -98,18 +105,31 @@ function SyllabusRow({
             </button>
         </Link>
     );
-}
+});
 
 function normalize(s: string) {
     return s.toLowerCase().replace(/[^a-z0-9]/g, "");
 }
 
+const INITIAL_VISIBLE_COUNT = 48;
+const LOAD_MORE_STEP = 48;
+
 export default function SyllabusGrid({ syllabi }: { syllabi: SyllabusItem[] }) {
     const [query, setQuery] = useState("");
     const [selected, setSelected] = useState<Set<string>>(new Set());
     const [isDownloading, setIsDownloading] = useState(false);
+    const [visibleCount, setVisibleCount] = useState(INITIAL_VISIBLE_COUNT);
     const inputRef = useRef<HTMLInputElement>(null);
+    const sentinelRef = useRef<HTMLDivElement>(null);
+    const { prefetch } = useRouter();
     const { toast } = useToast();
+
+    const prefetchHref = useCallback(
+        (href: string) => {
+            prefetch(href);
+        },
+        [prefetch],
+    );
 
     const syllabusById = useMemo(
         () => new Map(syllabi.map((syllabus) => [syllabus.id, syllabus])),
@@ -126,6 +146,38 @@ export default function SyllabusGrid({ syllabi }: { syllabi: SyllabusItem[] }) {
             return code.includes(q) || name.includes(q);
         });
     }, [query, syllabi]);
+
+    // Only render a window of the (possibly huge) result set so the main thread
+    // isn't blocked hydrating thousands of rows at once. More rows reveal as the
+    // sentinel scrolls into view.
+    const visible = useMemo(
+        () => filtered.slice(0, visibleCount),
+        [filtered, visibleCount],
+    );
+    const hasMore = visibleCount < filtered.length;
+
+    // Reset the window whenever the result set changes (e.g. on search).
+    useEffect(() => {
+        setVisibleCount(INITIAL_VISIBLE_COUNT);
+    }, [query]);
+
+    useEffect(() => {
+        if (!hasMore) return;
+        const sentinel = sentinelRef.current;
+        if (!sentinel) return;
+
+        const observer = new IntersectionObserver(
+            (entries) => {
+                if (entries.some((entry) => entry.isIntersecting)) {
+                    setVisibleCount((prev) => prev + LOAD_MORE_STEP);
+                }
+            },
+            { rootMargin: "600px 0px" },
+        );
+
+        observer.observe(sentinel);
+        return () => observer.disconnect();
+    }, [hasMore, visible.length]);
 
     const clear = () => {
         setQuery("");
@@ -227,16 +279,24 @@ export default function SyllabusGrid({ syllabi }: { syllabi: SyllabusItem[] }) {
                         </p>
                     )}
                     <div className="grid grid-cols-1 gap-1.5 sm:grid-cols-2">
-                        {filtered.map((s) => (
+                        {visible.map((s) => (
                             <SyllabusRow
                                 key={s.id}
                                 syllabus={s}
                                 selected={selected.has(s.id)}
                                 onToggleSelect={toggle}
                                 onDownload={downloadSyllabus}
+                                onPrefetch={prefetchHref}
                             />
                         ))}
                     </div>
+                    {hasMore && (
+                        <div
+                            ref={sentinelRef}
+                            aria-hidden="true"
+                            className="h-8 w-full"
+                        />
+                    )}
                 </div>
             )}
             {count > 0 && (

--- a/app/globals.css
+++ b/app/globals.css
@@ -874,16 +874,23 @@ html[data-native-tabs-pending="true"] .ec-mobile-tab-bar {
     animation: none;
 }
 
+/* `.nav-lateral-enter` / `.nav-lateral-exit` are the legacy keyed enter/exit
+   classes; `.nav-lateral` is the single class used by the persistent
+   ViewTransition's `update` path, where one group carries both the old and new
+   snapshots. All three are kept so the animation plays regardless of path. */
 ::view-transition-image-pair(.nav-lateral-enter),
-::view-transition-image-pair(.nav-lateral-exit) {
+::view-transition-image-pair(.nav-lateral-exit),
+::view-transition-image-pair(.nav-lateral) {
     overflow: clip;
 }
 
-::view-transition-old(.nav-lateral-exit) {
+::view-transition-old(.nav-lateral-exit),
+::view-transition-old(.nav-lateral) {
     animation: nav-lateral-hold 90ms linear both;
 }
 
-::view-transition-new(.nav-lateral-enter) {
+::view-transition-new(.nav-lateral-enter),
+::view-transition-new(.nav-lateral) {
     animation: nav-lateral-snap-in 90ms cubic-bezier(0.2, 0, 0, 1) both;
     z-index: 2;
 }

--- a/lib/posthog/client.ts
+++ b/lib/posthog/client.ts
@@ -106,6 +106,17 @@ function capturePostHogEvent(
         .catch(() => undefined);
 }
 
+function capturePostHogException(
+    error: Error,
+    properties?: AnalyticsProperties,
+) {
+    void initializePostHogClient()
+        .then((client) => {
+            client?.captureException(error, properties);
+        })
+        .catch(() => undefined);
+}
+
 function getQueryMetrics(query: string) {
     const trimmedQuery = query.trim();
     const queryTerms = trimmedQuery.split(/\s+/).filter(Boolean);
@@ -365,6 +376,43 @@ export function captureQuizSubmitted(input: {
                 ? Math.round((input.score / input.totalQuestions) * 100)
                 : 0,
     });
+}
+
+export type PdfPageRenderFailureReason =
+    | "render_error"
+    | "render_timeout"
+    | "empty_blob";
+
+export function capturePdfPageRenderFailed(input: {
+    documentId: string;
+    pageIndex: number;
+    reason: PdfPageRenderFailureReason;
+    timeoutMs?: number;
+    errorMessage?: string | null;
+}) {
+    const properties: AnalyticsProperties = {
+        pdf_document_id: input.documentId,
+        pdf_page_index: input.pageIndex,
+        pdf_page_number: input.pageIndex + 1,
+        failure_reason: input.reason,
+        timeout_ms: input.timeoutMs,
+        error_message: input.errorMessage?.slice(0, 500),
+    };
+
+    // Custom event so the blank-viewer failure rate is measurable in funnels
+    // and dashboards alongside the `content_viewed` event.
+    capturePostHogEvent("pdf_page_render_failed", properties);
+
+    // Also surface it as a `$exception` in Error Tracking. The render catch
+    // previously only `console.error`-ed, so these failures never reached
+    // PostHog and the true failure rate was invisible.
+    const error = new Error(
+        `PDF page render ${input.reason} (document ${input.documentId}, page ${
+            input.pageIndex + 1
+        })${input.errorMessage ? `: ${input.errorMessage}` : ""}`,
+    );
+    error.name = "PdfPageRenderError";
+    capturePostHogException(error, properties);
 }
 
 export function capturePdfDownloaded(input: {

--- a/lib/posthog/shared.ts
+++ b/lib/posthog/shared.ts
@@ -27,6 +27,19 @@ const SCRIPT_ERROR_SENTINEL = "Script error.";
 const EXTENSION_RPC_REJECTION_SIGNATURE =
     /^Non-Error promise rejection captured with value: Object Not Found Matching Id:\d+, MethodName:update, ParamCount:4$/;
 
+// Browser extensions (commonly on Mobile Safari) that message their background
+// page after their tab has gone away throw "Invalid call to
+// runtime.sendMessage(). Tab not found." posthog-js captures the extension's
+// synthetic, unhandled Error and wraps it, so the value looks like
+// "'Error' captured as exception with message: 'Invalid call to
+// runtime.sendMessage(). Tab not found.'". It carries no stack and no examcooker
+// code, so it is pure noise we drop before it reaches error tracking.
+//
+// Match the exact wrapped extension message so a genuine app error that happens
+// to mention runtime.sendMessage still surfaces.
+const EXTENSION_SENDMESSAGE_SIGNATURE =
+    /^'Error' captured as exception with message: 'Invalid call to runtime\.sendMessage\(\)\. Tab not found\.'$/;
+
 function hasNoFrames(entry: { stacktrace?: { frames?: unknown[] } | null }) {
     // A genuinely sanitized/synthetic exception carries no usable stack. If the
     // entry has frames, it is a real, actionable exception that merely happens
@@ -72,10 +85,31 @@ function isUnactionableExtensionRejection(exception: unknown): boolean {
     return hasNoFrames(entry);
 }
 
+function isUnactionableExtensionSendMessage(exception: unknown): boolean {
+    if (!exception || typeof exception !== "object") {
+        return false;
+    }
+
+    const entry = exception as {
+        value?: unknown;
+        stacktrace?: { frames?: unknown[] } | null;
+    };
+
+    if (
+        typeof entry.value !== "string" ||
+        !EXTENSION_SENDMESSAGE_SIGNATURE.test(entry.value)
+    ) {
+        return false;
+    }
+
+    return hasNoFrames(entry);
+}
+
 function isUnactionableEntry(exception: unknown): boolean {
     return (
         isUnactionableScriptError(exception) ||
-        isUnactionableExtensionRejection(exception)
+        isUnactionableExtensionRejection(exception) ||
+        isUnactionableExtensionSendMessage(exception)
     );
 }
 

--- a/lib/posthog/shared.ts
+++ b/lib/posthog/shared.ts
@@ -207,6 +207,82 @@ function isRrwebCrossOriginIframeException(result: CaptureResult): boolean {
     });
 }
 
+// On iOS, Capacitor's injected `native-bridge.js` registers a `pagehide`
+// listener (`sendPageHideMessage`) that funnels through `sendDataToNative`,
+// which posts to `window.webkit.messageHandlers.bridge`. While the WKWebView is
+// tearing down during navigation, `window.webkit.messageHandlers` is already
+// `undefined`, so the access throws
+// `TypeError: undefined is not an object (evaluating 'window.webkit.messageHandlers')`.
+// posthog-js (running inside the WebView) then captures it as an unhandled
+// exception. The page is already unloading, so nothing user-facing breaks — it
+// is pure teardown-race noise from a third-party bridge, not our code.
+//
+// We match narrowly: the exact `window.webkit.messageHandlers` access message
+// AND a Capacitor bridge frame (`sendPageHideMessage` / `sendDataToNative`).
+// Neither symbol exists anywhere in examcooker's own code, and requiring the
+// bridge frame keeps any unrelated future `webkit.messageHandlers` throw
+// visible.
+const CAPACITOR_WEBKIT_HANDLER_MESSAGE = "window.webkit.messageHandlers";
+const CAPACITOR_BRIDGE_FRAME_FUNCTIONS = new Set([
+    "sendPageHideMessage",
+    "sendDataToNative",
+]);
+
+function hasCapacitorBridgeFrame(exception: {
+    stacktrace?: { frames?: unknown[] } | null;
+}): boolean {
+    const frames = exception.stacktrace?.frames;
+    if (!Array.isArray(frames)) return false;
+
+    return frames.some((frame) => {
+        const fn =
+            frame && typeof frame === "object"
+                ? (frame as { function?: unknown }).function
+                : undefined;
+        return typeof fn === "string" && CAPACITOR_BRIDGE_FRAME_FUNCTIONS.has(fn);
+    });
+}
+
+function isCapacitorTeardownException(exception: unknown): boolean {
+    if (!exception || typeof exception !== "object") {
+        return false;
+    }
+
+    const entry = exception as {
+        type?: unknown;
+        value?: unknown;
+        stacktrace?: { frames?: unknown[] } | null;
+    };
+
+    if (entry.type !== "TypeError") {
+        return false;
+    }
+
+    if (
+        typeof entry.value !== "string" ||
+        !entry.value.includes(CAPACITOR_WEBKIT_HANDLER_MESSAGE)
+    ) {
+        return false;
+    }
+
+    return hasCapacitorBridgeFrame(entry);
+}
+
+function isCapacitorBridgeTeardownNoise(event: CaptureResult): boolean {
+    if (event.event !== "$exception") {
+        return false;
+    }
+
+    const exceptionList = event.properties?.$exception_list;
+    if (!Array.isArray(exceptionList) || exceptionList.length === 0) {
+        return false;
+    }
+
+    // Only drop when EVERY entry is the benign Capacitor teardown throw, so an
+    // event chaining it with a genuine exception keeps its actionable detail.
+    return exceptionList.every(isCapacitorTeardownException);
+}
+
 function beforeSend(result: CaptureResult | null): CaptureResult | null {
     const filteredResult = dropScriptErrorNoise(result);
     if (!filteredResult) {
@@ -216,6 +292,11 @@ function beforeSend(result: CaptureResult | null): CaptureResult | null {
     if (isRrwebCrossOriginIframeException(filteredResult)) {
         return null;
     }
+
+    if (isCapacitorBridgeTeardownNoise(filteredResult)) {
+        return null;
+    }
+
     return filteredResult;
 }
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -91,8 +91,15 @@ const configuredRemotePatterns = Array.from(
     ).values(),
 ).filter((pattern): pattern is RemotePattern => pattern !== null);
 
+// Emit browser source maps only when we intend to upload them to PostHog error
+// tracking (set by the deploy workflow when the PostHog CLI secrets are present).
+// The upload step strips the `.map` files back out before packaging, so they are
+// never served publicly. Off by default, so ordinary builds are unaffected.
+const uploadSourceMaps = process.env.POSTHOG_SOURCEMAP_UPLOAD === "true";
+
 const nextConfig: NextConfig = {
     output: "standalone",
+    productionBrowserSourceMaps: uploadSourceMaps,
     cacheComponents: true,
     partialPrefetching: true,
     compiler: {


### PR DESCRIPTION
<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR improves production diagnostics and recovery behavior across deploy, auth, PDF rendering, and UI navigation. The main changes are:

- Adds opt-in PostHog source-map upload during App Service deploys.
- Enables browser source maps only when upload is explicitly gated on.
- Clears session cookies after account deletion and rejects JWT sessions for deleted users.
- Converts PDF page render failures, timeouts, and empty blobs into retry UI plus analytics.
- Adds WebGL context loss recovery for the pixel background.
- Keeps page view transitions persistent instead of remounting the route subtree.
- Windows large syllabus result sets and prefetches syllabus pages on user intent.
- Filters additional PostHog exception noise from browser extensions and Capacitor teardown.

<h3>Confidence Score: 5/5</h3>

Safe to merge with low risk.

The changes are mostly defensive recovery, analytics filtering, and gated deploy behavior; no verified issues were found.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The app process was running, as shown by Playwright captures and dev logs.
- The home route responded with HTTP 500 due to a server-side missing DATABASE\_URL in db/index.ts.
- Before-scope and after-scope screenshots both show the home route in the HTTP 500 state.
- The dev logs confirm the cause by reporting the server error DATABASE\_URL is not set.

<a href="https://app.greptile.com/trex/runs/15080312/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/deploy-appservice.yml | Adds an opt-in PostHog source map upload step gated by CLI secrets, with map cleanup before packaging. |
| app/api/account/delete/route.ts | Clears known Auth.js/NextAuth session cookies after account deletion in addition to deleting server-side state. |
| app/auth.ts | Invalidates JWT sessions whose backing user row is missing or marked with the deleted-account email domain. |
| app/components/pdfviewer.tsx | Converts PDF page render errors, timeouts, and empty blobs into retry UI and analytics reporting. |
| app/components/syllabus/syllabus-grid.tsx | Windows large syllabus result sets, lazy-loads additional rows via IntersectionObserver, and prefetches links on intent. |
| lib/posthog/client.ts | Adds PDF page render failure analytics and PostHog exception capture for render failures. |
| lib/posthog/shared.ts | Extends PostHog before-send filtering for extension sendMessage noise and Capacitor pagehide bridge teardown exceptions. |
| next.config.ts | Enables production browser source maps only when the deploy workflow explicitly opts into PostHog upload. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
  participant Browser as Browser UI
  participant Pdf as PDF PageRenderLayer
  participant PH as PostHog client
  participant Auth as Auth callbacks
  participant DB as Postgres
  participant Deploy as GitHub Actions deploy
  participant CLI as PostHog CLI

  Browser->>Pdf: render page blob
  alt render fails, times out, or empty blob
    Pdf->>Browser: show retry UI
    Pdf->>PH: capture pdf_page_render_failed + exception
  else render succeeds
    Pdf->>Browser: display object URL image
  end

  Browser->>Auth: request with JWT session
  Auth->>DB: verify user row/email and refresh role
  alt user missing or deleted marker
    Auth-->>Browser: invalidate session flow
  else active user
    Auth-->>Browser: session with role
  end

  Deploy->>Deploy: build with POSTHOG_SOURCEMAP_UPLOAD gate
  alt CLI token and env id configured
    Deploy->>CLI: inject chunk ids
    Deploy->>CLI: upload source maps
    Deploy->>Deploy: delete .map files before packaging
  end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
  participant Browser as Browser UI
  participant Pdf as PDF PageRenderLayer
  participant PH as PostHog client
  participant Auth as Auth callbacks
  participant DB as Postgres
  participant Deploy as GitHub Actions deploy
  participant CLI as PostHog CLI

  Browser->>Pdf: render page blob
  alt render fails, times out, or empty blob
    Pdf->>Browser: show retry UI
    Pdf->>PH: capture pdf_page_render_failed + exception
  else render succeeds
    Pdf->>Browser: display object URL image
  end

  Browser->>Auth: request with JWT session
  Auth->>DB: verify user row/email and refresh role
  alt user missing or deleted marker
    Auth-->>Browser: invalidate session flow
  else active user
    Auth-->>Browser: session with role
  end

  Deploy->>Deploy: build with POSTHOG_SOURCEMAP_UPLOAD gate
  alt CLI token and env id configured
    Deploy->>CLI: inject chunk ids
    Deploy->>CLI: upload source maps
    Deploy->>Deploy: delete .map files before packaging
  end
```

</a>

<sub>Reviews (1): Last reviewed commit: ["Merge pull request #477 from ACM-VIT/cur..."](https://github.com/acm-vit/examcooker/commit/9d7d6a9d99c48612b997c1beb93545fa3ff8ff29) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45617157)</sub>

<!-- /greptile_comment -->