### PR TITLE
Dev

### DIFF
--- a/app/hydration-recovery-script.ts
+++ b/app/hydration-recovery-script.ts
@@ -1,0 +1,21 @@
+import {
+  HYDRATION_RECOVERY_INCIDENT_KEY,
+  RELOAD_FLAG,
+  RELOAD_GUARD_TTL_MS,
+} from "./global-error-reload-guard";
+
+// React reports #418/#419 hydration mismatches as *recoverable* errors emitted
+// *during* the initial hydration pass — before any React `useEffect` runs — so
+// a listener attached from a client component would miss the very first blank
+// or corrupted viewer of the session. Install the global `error` listener here,
+// before hydration, so a mismatch is caught the moment it fires: perform the
+// same guarded, one-time `location.reload()` recovery used for `ChunkLoadError`
+// (reusing the same reload guard so it can't loop) and record the incident so
+// `HydrationRecovery` can report it to PostHog once the page is stable. Kept as
+// a string constant (not a regex) so no escaping is mangled when inlined. The
+// numbers cover the recoverable hydration error codes React can emit.
+export const hydrationRecoveryInitScript = `(function(){try{var FLAG=${JSON.stringify(
+  RELOAD_FLAG,
+)},INC=${JSON.stringify(
+  HYDRATION_RECOVERY_INCIDENT_KEY,
+)},TTL=${RELOAD_GUARD_TTL_MS},NUMS={418:1,419:1,420:1,421:1,422:1,423:1,425:1},handled=false;function isHy(m){if(!m)return false;m=''+m;var l=m.toLowerCase();var i=m.indexOf('Minified React error #');if(i!==-1){var n='';for(var j=i+22;j<m.length;j++){var c=m.charCodeAt(j);if(c>=48&&c<=57){n+=m.charAt(j);}else{break;}}if(n&&NUMS[+n])return true;}return l.indexOf('hydrat')!==-1||l.indexOf('did not match')!==-1||l.indexOf('text content does not match')!==-1;}window.addEventListener('error',function(e){if(handled)return;var err=e&&e.error,msg=(err&&err.message)||(e&&e.message)||'';if(!isHy(msg))return;handled=true;var key='hydration:'+((err&&err.name)||'Error')+':'+msg+':'+((err&&err.digest)||''),reload=false;try{var raw=sessionStorage.getItem(FLAG),fresh=false;if(raw){var g=JSON.parse(raw);fresh=!!g&&g.key===key&&(Date.now()-g.timestamp)<TTL;}if(!fresh){sessionStorage.setItem(FLAG,JSON.stringify({key:key,timestamp:Date.now()}));reload=true;}}catch(_){}try{sessionStorage.setItem(INC,JSON.stringify({path:location.pathname,message:(''+msg).slice(0,500),reloadTriggered:reload}));}catch(_){}if(reload){location.reload();}});}catch(_){}})();`;

--- a/app/hydration-recovery.tsx
+++ b/app/hydration-recovery.tsx
@@ -58,7 +58,7 @@ export default function HydrationRecovery() {
     const path =
       typeof incident.path === "string"
         ? incident.path
-        : window.location.pathname + window.location.search;
+        : window.location.pathname;
 
     captureHydrationMismatchRecovered({
       path,

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,11 +7,7 @@ import UpsellToast from "@/app/components/ui/upsell-toast";
 import UpsellModal from "@/app/components/ui/upsell-modal";
 import PwaServiceWorker from "@/app/components/pwa-service-worker";
 import HydrationRecovery from "@/app/hydration-recovery";
-import {
-    HYDRATION_RECOVERY_INCIDENT_KEY,
-    RELOAD_FLAG,
-    RELOAD_GUARD_TTL_MS,
-} from "@/app/global-error-reload-guard";
+import { hydrationRecoveryInitScript } from "@/app/hydration-recovery-script";
 import CapacitorBridge from "@/app/components/capacitor-bridge";
 import NativeIosTabSync from "@/app/components/native-ios-tab-sync";
 import AndroidInstallBanner from "@/app/components/android-install-banner";
@@ -89,22 +85,6 @@ export const metadata: Metadata = {
     },
 };
 const plus_jakarta_sans = Plus_Jakarta_Sans({ subsets: ["latin"] });
-
-// React reports #418/#419 hydration mismatches as *recoverable* errors emitted
-// *during* the initial hydration pass — before any React `useEffect` runs — so
-// a listener attached from a client component would miss the very first blank
-// or corrupted viewer of the session. Install the global `error` listener here,
-// before hydration, so a mismatch is caught the moment it fires: perform the
-// same guarded, one-time `location.reload()` recovery used for `ChunkLoadError`
-// (reusing the same reload guard so it can't loop) and record the incident so
-// `HydrationRecovery` can report it to PostHog once the page is stable. Kept as
-// a string constant (not a regex) so no escaping is mangled when inlined. The
-// numbers cover the recoverable hydration error codes React can emit.
-const hydrationRecoveryInitScript = `(function(){try{var FLAG=${JSON.stringify(
-    RELOAD_FLAG,
-)},INC=${JSON.stringify(
-    HYDRATION_RECOVERY_INCIDENT_KEY,
-)},TTL=${RELOAD_GUARD_TTL_MS},NUMS={418:1,419:1,420:1,421:1,422:1,423:1,425:1},handled=false;function isHy(m){if(!m)return false;m=''+m;var l=m.toLowerCase();var i=m.indexOf('Minified React error #');if(i!==-1){var n='';for(var j=i+22;j<m.length;j++){var c=m.charCodeAt(j);if(c>=48&&c<=57){n+=m.charAt(j);}else{break;}}if(n&&NUMS[+n])return true;}return l.indexOf('hydrat')!==-1||l.indexOf('did not match')!==-1||l.indexOf('text content does not match')!==-1;}window.addEventListener('error',function(e){if(handled)return;var err=e&&e.error,msg=(err&&err.message)||(e&&e.message)||'';if(!isHy(msg))return;handled=true;var key='hydration:'+((err&&err.name)||'Error')+':'+msg+':'+((err&&err.digest)||''),reload=false;try{var raw=sessionStorage.getItem(FLAG),fresh=false;if(raw){var g=JSON.parse(raw);fresh=!!g&&g.key===key&&(Date.now()-g.timestamp)<TTL;}if(!fresh){sessionStorage.setItem(FLAG,JSON.stringify({key:key,timestamp:Date.now()}));reload=true;}}catch(_){}try{sessionStorage.setItem(INC,JSON.stringify({path:location.pathname+location.search,message:(''+msg).slice(0,500),reloadTriggered:reload}));}catch(_){}if(reload){location.reload();}});}catch(_){}})();`;
 
 function GoogleAnalytics({ gaId }: { gaId: string }) {
     return (

--- a/lib/posthog/client.ts
+++ b/lib/posthog/client.ts
@@ -479,8 +479,9 @@ export function captureHydrationMismatchRecovered(input: {
     errorMessage?: string | null;
     reloadTriggered: boolean;
 }) {
+    const safePath = input.path.split(/[?#]/, 1)[0] || "/";
     const properties: AnalyticsProperties = {
-        path: input.path,
+        path: safePath,
         react_error_number: input.reactErrorNumber,
         error_message: input.errorMessage?.slice(0, 500),
         reload_triggered: input.reloadTriggered,
@@ -502,7 +503,7 @@ export function captureHydrationMismatchRecovered(input: {
     const error = new Error(
         `Hydration mismatch recovered${
             input.reactErrorNumber ? ` (React #${input.reactErrorNumber})` : ""
-        } on ${input.path}${input.reloadTriggered ? " — reloaded" : ""}`,
+        } on ${safePath}${input.reloadTriggered ? " — reloaded" : ""}`,
     );
     error.name = "HydrationMismatchRecovered";
     capturePostHogException(error, properties);

--- a/scripts/test-global-error-reload-guard.ts
+++ b/scripts/test-global-error-reload-guard.ts
@@ -71,7 +71,7 @@ try {
     "hydration recovery keys include the trailing digest field used by the inline guard",
   );
   assert.match(
-    readFileSync(new URL("../app/layout.tsx", import.meta.url), "utf8"),
+    readFileSync(new URL("../app/hydration-recovery-script.ts", import.meta.url), "utf8"),
     /\+':'\+\(\(err&&err\.digest\)\|\|''\)/,
     "the pre-hydration inline guard must use the same digest-aware key shape",
   );

--- a/scripts/test-hydration-recovery-privacy.ts
+++ b/scripts/test-hydration-recovery-privacy.ts
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import {
+  HYDRATION_RECOVERY_INCIDENT_KEY,
+  RELOAD_FLAG,
+} from "../app/global-error-reload-guard";
+import { hydrationRecoveryInitScript } from "../app/hydration-recovery-script";
+
+type ErrorHandler = (event: {
+  error?: Error;
+  message?: string;
+}) => void;
+
+function createMemoryStorage() {
+  const entries = new Map<string, string>();
+  return {
+    getItem(key: string) {
+      return entries.get(key) ?? null;
+    },
+    setItem(key: string, value: string) {
+      entries.set(key, value);
+    },
+    removeItem(key: string) {
+      entries.delete(key);
+    },
+  };
+}
+
+const realSessionStorage = globalThis.sessionStorage;
+const realLocation = globalThis.location;
+const realWindow = globalThis.window;
+
+try {
+  const storage = createMemoryStorage();
+  const errorHandlers: ErrorHandler[] = [];
+  let reloadCount = 0;
+
+  Object.defineProperty(globalThis, "sessionStorage", {
+    configurable: true,
+    value: storage,
+  });
+  Object.defineProperty(globalThis, "location", {
+    configurable: true,
+    value: {
+      pathname: "/native-auth/complete",
+      search:
+        "?code=secret-code&handoffChallenge=secret-challenge&returnTo=%2Fdashboard",
+      reload() {
+        reloadCount += 1;
+      },
+    },
+  });
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      addEventListener(type: string, handler: ErrorHandler) {
+        if (type === "error") {
+          errorHandlers.push(handler);
+        }
+      },
+    },
+  });
+
+  new Function(hydrationRecoveryInitScript)();
+
+  assert.equal(errorHandlers.length, 1, "script installs one error listener");
+  errorHandlers[0]({
+    error: new Error("Minified React error #418; see https://react.dev/errors/418"),
+  });
+
+  assert.equal(reloadCount, 1, "hydration recovery still triggers guarded reload");
+  assert.ok(
+    storage.getItem(RELOAD_FLAG),
+    "hydration recovery still writes the reload guard",
+  );
+
+  const rawIncident = storage.getItem(HYDRATION_RECOVERY_INCIDENT_KEY);
+  assert.ok(rawIncident, "hydration recovery records an incident");
+  const incident = JSON.parse(rawIncident);
+  assert.equal(
+    incident.path,
+    "/native-auth/complete",
+    "incident path must not include sensitive auth query parameters",
+  );
+  assert.equal(
+    rawIncident.includes("secret-code") || rawIncident.includes("secret-challenge"),
+    false,
+    "incident payload must not persist auth handoff secrets",
+  );
+
+  console.log("hydration recovery privacy tests passed");
+} finally {
+  Object.defineProperty(globalThis, "sessionStorage", {
+    configurable: true,
+    value: realSessionStorage,
+  });
+  Object.defineProperty(globalThis, "location", {
+    configurable: true,
+    value: realLocation,
+  });
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: realWindow,
+  });
+}


### PR DESCRIPTION
<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This PR prevents hydration-recovery telemetry from retaining URL query strings and extracts the early recovery script into a dedicated module.
- Records only `location.pathname` in hydration incidents and sanitizes telemetry paths defensively.
- Updates the reporter fallback to avoid query parameters.
- Adds a privacy regression script and adjusts the reload-guard script test for the extracted module.
- The generic title “Dev” does not communicate this privacy-focused change; a more descriptive commit/PR title would improve history.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with the non-blocking caveat that its new privacy regression test should be wired into automated verification.

The runtime path consistently stores and reports pathname-only telemetry, while the sole accepted concern is that the regression test currently runs only when invoked manually.

**Files Needing Attention:** scripts/test-hydration-recovery-privacy.ts

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Executed the native-auth hydration-recovery path with sensitive query and fragment values.
- Verified that persisted incidents and telemetry retained only /native-auth/complete, while the guarded reload ran once.
- Ran the focused privacy and reload-guard scripts successfully.
- Before and after, confirmed that storage and reporter output contain only /native-auth/complete; containsSecrets is false, reload count is 1, and the guard is present.
- All after assertions and focused repository scripts exited with code 0.

<a href="https://app.greptile.com/trex/runs/16188935/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/hydration-recovery-script.ts | Extracts the global pre-hydration listener and changes incident storage to retain only the pathname. |
| app/hydration-recovery.tsx | Removes query strings from the fallback path used by the hydration incident reporter. |
| app/layout.tsx | Replaces the local script definition with the extracted recovery-script import. |
| lib/posthog/client.ts | Sanitizes hydration telemetry paths before constructing event and exception properties. |
| scripts/test-hydration-recovery-privacy.ts | Verifies auth query parameters are not persisted, but the new regression script is not connected to automated verification. |
| scripts/test-global-error-reload-guard.ts | Updates the source assertion to inspect the extracted recovery-script module. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
participant B as Browser
participant S as Pre-hydration script
participant R as HydrationRecovery
participant P as PostHog
B->>S: Hydration error
S->>S: Store pathname-only incident
S->>B: Guarded reload
B->>R: Stable hydration
R->>R: Read and clear incident
R->>P: Report sanitized path
```
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22acm-vit%2Fexamcooker%22%20on%20the%20existing%20branch%20%22dev%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22dev%22.%0A%0A%23%23%23%20Issue%201%0Ascripts%2Ftest-hydration-recovery-privacy.ts%3A1%0A**Privacy%20test%20is%20not%20automated**%0A%0AThis%20regression%20test%20is%20not%20invoked%20by%20a%20package%20script%20or%20the%20deployment%20workflow%2C%20so%20later%20changes%20that%20restore%20sensitive%20query%20parameters%20to%20hydration%20telemetry%20will%20merge%20without%20this%20check%20running.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=acm-vit%2Fexamcooker&pr=496&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Ascripts%2Ftest-hydration-recovery-privacy.ts%3A1%0A**Privacy%20test%20is%20not%20automated**%0A%0AThis%20regression%20test%20is%20not%20invoked%20by%20a%20package%20script%20or%20the%20deployment%20workflow%2C%20so%20later%20changes%20that%20restore%20sensitive%20query%20parameters%20to%20hydration%20telemetry%20will%20merge%20without%20this%20check%20running.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=acm-vit%2Fexamcooker&pr=496&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Ascripts%2Ftest-hydration-recovery-privacy.ts%3A1%0A**Privacy%20test%20is%20not%20automated**%0A%0AThis%20regression%20test%20is%20not%20invoked%20by%20a%20package%20script%20or%20the%20deployment%20workflow%2C%20so%20later%20changes%20that%20restore%20sensitive%20query%20parameters%20to%20hydration%20telemetry%20will%20merge%20without%20this%20check%20running.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=496&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Merge pull request #495 from ACM-VIT/cur..."](https://github.com/acm-vit/examcooker/commit/3072c9bd9a4502d89feccd2378f464c4d43125af) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47916727)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->