### PR TITLE
fix: restore VInTogether sync on TypeScript 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "tailwindcss": "^4.3.3",
     "tsx": "^4.23.1",
     "typescript": "^7.0.2",
+    "typescript-api": "npm:typescript@6.0.3",
     "wrangler": "^4.118.0"
   },
   "overrides": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -267,6 +267,9 @@ importers:
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
+      typescript-api:
+        specifier: npm:typescript@6.0.3
+        version: typescript@6.0.3
       wrangler:
         specifier: ^4.118.0
         version: 4.118.0(@cloudflare/workers-types@5.20260730.1)

--- a/scripts/sync-vin-together.js
+++ b/scripts/sync-vin-together.js
@@ -2,7 +2,10 @@
 
 const fs = require("fs");
 const path = require("path");
-const ts = require("typescript");
+// TypeScript 7's root export is the native CLI and does not expose the legacy
+// compiler JavaScript API used by this source-map parser. Keep that API isolated
+// behind an npm alias while the application itself continues to compile with 7.
+const ts = require("typescript-api");
 
 const SITE_ORIGIN = "https://v-in-together.vercel.app";
 const COURSES_URL = `${SITE_ORIGIN}/courses`;


### PR DESCRIPTION
## Summary

- keep TypeScript 7 as the application compiler
- use a TypeScript 6 npm alias for the legacy compiler API required by the VInTogether parser
- restore clean CI builds when no generated course-data cache exists

## Verification

- clean npm install and production build without lib/generated/vinTogether.json
- pnpm exec tsc --noEmit --pretty false
- pnpm install --frozen-lockfile
- pnpm audit --json (0 vulnerabilities)