### PR TITLE
fix: separate Redis connection and command timeouts

### DIFF
--- a/lib/redis.ts
+++ b/lib/redis.ts
@@ -3,6 +3,7 @@ import "server-only";
 import { createClient, type RedisClientOptions } from "redis";
 
 const DEFAULT_CONNECT_TIMEOUT_MS = 5_000;
+const DEFAULT_READY_TIMEOUT_MS = 10_000;
 const DEFAULT_COMMAND_TIMEOUT_MS = 2_000;
 const DEFAULT_PING_INTERVAL_MS = 5 * 60_000;
 
@@ -180,21 +181,42 @@ async function getConnectedClient() {
 async function withCommandTimeout<T>(
   operation: (client: RawRedisClient) => Promise<T>,
 ) {
+  const readyTimeoutMs = readPositiveIntegerEnv(
+    "REDIS_READY_TIMEOUT_MS",
+    DEFAULT_READY_TIMEOUT_MS,
+  );
   const timeoutMs = readPositiveIntegerEnv(
     "REDIS_COMMAND_TIMEOUT_MS",
     DEFAULT_COMMAND_TIMEOUT_MS,
   );
+  let readyTimeout: NodeJS.Timeout | undefined;
+
+  const client = await Promise.race([
+    getConnectedClient(),
+    new Promise<never>((_, reject) => {
+      readyTimeout = setTimeout(() => {
+        reject(
+          new Error(
+            `Redis connection was not ready after ${readyTimeoutMs}ms`,
+          ),
+        );
+      }, readyTimeoutMs);
+    }),
+  ]).finally(() => {
+    if (readyTimeout) {
+      clearTimeout(readyTimeout);
+    }
+  });
+
   const abortController = new AbortController();
   let timeout: NodeJS.Timeout | undefined;
 
   try {
     return await Promise.race([
-      getConnectedClient().then((client) =>
-        operation(
-          client.withCommandOptions({
-            abortSignal: abortController.signal,
-          }) as RawRedisClient,
-        ),
+      operation(
+        client.withCommandOptions({
+          abortSignal: abortController.signal,
+        }) as RawRedisClient,
       ),
       new Promise<never>((_, reject) => {
         timeout = setTimeout(() => {


### PR DESCRIPTION
## Summary
- allow managed-identity token acquisition and TLS connection setup up to 10 seconds
- start the 2-second command timeout only after the Redis client is ready
- preserve abortable, bounded Redis commands and fail-open request behavior

## Production finding
Azure metrics showed the private connection was established, while App Service logs showed the first command deadline expiring during cold authentication. This fixes the timing boundary directly.

## Verification
- `pnpm exec tsc --noEmit`
- `pnpm build`
- real local Redis adapter and limiter integration test with separate ready/command settings

<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This change separates Redis connection readiness from command execution timing. A mocked Redis exercise confirmed that a client becoming ready after the short command deadline can still complete a fast command when it becomes ready within the readiness deadline. It also confirmed that a client which never becomes ready fails at the configured readiness timeout instead of waiting indefinitely. No defects were found.

<h3>Confidence Score: 5/5</h3>

The timeout separation behaves as intended for both delayed-ready and never-ready Redis connections.

The public Redis client path was exercised with controlled readiness and command timings, including a comparison with the preceding implementation. The observed behavior confirms that command timing now starts only after readiness and that stalled readiness remains bounded.

**Files Needing Attention:** No additional files need attention; the validated behavior is contained in lib/redis.ts.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a mocked Redis harness against both lib/redis.ts implementations through the getOptionalRedis().get() path to compare readiness and command timeout behavior.
- Under a 40 ms command timeout with a 100 ms readiness delay and a 220 ms readiness timeout, the older implementation timed out while the checked-out implementation returned quick-value.
- Under a 90 ms readiness timeout with a client that never became ready, the checked-out implementation rejected after the readiness window.
- After running the capture, readiness no longer consumes the command deadline and stalled readiness is bounded.
- After capture, delayed readiness resolves with quick-value and never-ready yields the configured readiness-timeout error.

<a href="https://app.greptile.com/trex/runs/17673465/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: separate Redis connection and comma..."](https://github.com/acm-vit/examcooker/commit/d6cce8d3780ae4a4beff7c33f82f296396b76f1b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50909553)</sub>

<!-- /greptile_comment -->