### PR TITLE
feat: add live Azure observability dashboard

### DIFF
--- a/app/(mod)/mod/observability/azure-observability-dashboard.tsx
+++ b/app/(mod)/mod/observability/azure-observability-dashboard.tsx
@@ -1,0 +1,640 @@
+"use client";
+
+import Link from "next/link";
+import {
+  Activity,
+  ArrowLeft,
+  CircleGauge,
+  Clock3,
+  Cloud,
+  Cpu,
+  DatabaseZap,
+  Gauge,
+  RefreshCw,
+  Server,
+  ShieldCheck,
+  Siren,
+  TimerReset,
+  Waves,
+} from "lucide-react";
+import {
+  type ComponentType,
+  type SVGProps,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import {
+  AZURE_MONITOR_RANGES,
+  type AzureMonitorPoint,
+  type AzureMonitorRange,
+  type AzureMonitorSnapshot,
+} from "@/lib/azure-monitor-types";
+import styles from "./observability.module.css";
+
+const RANGE_LABELS: Record<AzureMonitorRange, string> = {
+  "1h": "Live · 1H",
+  "24h": "24H",
+  "7d": "7D",
+  "30d": "30D",
+};
+
+const RANGE_COPY: Record<AzureMonitorRange, string> = {
+  "1h": "one-minute resolution",
+  "24h": "five-minute resolution",
+  "7d": "hourly resolution",
+  "30d": "six-hour resolution",
+};
+
+const SERVER_ERROR_BUDGET_PERCENT = 0.5;
+
+type Icon = ComponentType<SVGProps<SVGSVGElement>>;
+type MetricKey = keyof Pick<
+  AzureMonitorPoint,
+  | "rps"
+  | "cpuPercent"
+  | "memoryPercent"
+  | "responseTimeMs"
+  | "errorRatePercent"
+  | "queueLength"
+>;
+
+type ChartLine = {
+  key: MetricKey;
+  label: string;
+  color: string;
+};
+
+function formatCompact(value: number) {
+  return new Intl.NumberFormat("en-IN", {
+    maximumFractionDigits: value >= 1_000 ? 1 : 0,
+    notation: value >= 1_000 ? "compact" : "standard",
+  }).format(value);
+}
+
+function formatDecimal(value: number, digits = 1) {
+  return new Intl.NumberFormat("en-IN", {
+    maximumFractionDigits: digits,
+    minimumFractionDigits: digits,
+  }).format(value);
+}
+
+function formatLatency(valueMs: number) {
+  if (valueMs >= 1_000) return `${formatDecimal(valueMs / 1_000, 2)} s`;
+  return `${formatCompact(valueMs)} ms`;
+}
+
+function formatMetricAge(timestamp: string | null) {
+  if (!timestamp) return "waiting for Azure";
+  const ageSeconds = Math.max(
+    0,
+    Math.round((Date.now() - new Date(timestamp).getTime()) / 1_000),
+  );
+  if (ageSeconds < 60) return `${ageSeconds}s behind`;
+  return `${Math.round(ageSeconds / 60)}m behind`;
+}
+
+function formatUpdatedAt(timestamp: string) {
+  return new Intl.DateTimeFormat("en-IN", {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  }).format(new Date(timestamp));
+}
+
+function chartTimestamp(timestamp: string, range: AzureMonitorRange) {
+  const options: Intl.DateTimeFormatOptions =
+    range === "1h" || range === "24h"
+      ? { hour: "2-digit", minute: "2-digit", hour12: false }
+      : { day: "2-digit", month: "short" };
+  return new Intl.DateTimeFormat("en-IN", options).format(new Date(timestamp));
+}
+
+function buildLinePath(
+  series: AzureMonitorPoint[],
+  key: MetricKey,
+  maxValue: number,
+) {
+  if (series.length < 2) return "";
+  let path = "";
+  let drawing = false;
+  for (let index = 0; index < series.length; index += 1) {
+    const value = series[index]?.[key];
+    if (typeof value !== "number" || !Number.isFinite(value)) {
+      drawing = false;
+      continue;
+    }
+    const x = (index / (series.length - 1)) * 1000;
+    const y = 210 - Math.min(1, Math.max(0, value / maxValue)) * 178;
+    path += `${drawing ? "L" : "M"}${x.toFixed(1)},${y.toFixed(1)} `;
+    drawing = true;
+  }
+  return path.trim();
+}
+
+function MetricChart({
+  description,
+  empty,
+  fixedMaximum,
+  lines,
+  range,
+  series,
+  title,
+  valueLabel,
+}: {
+  description: string;
+  empty: boolean;
+  fixedMaximum?: number;
+  lines: ChartLine[];
+  range: AzureMonitorRange;
+  series: AzureMonitorPoint[];
+  title: string;
+  valueLabel: string;
+}) {
+  const allValues = lines.flatMap((line) =>
+    series.flatMap((point) => {
+      const value = point[line.key];
+      return typeof value === "number" && Number.isFinite(value) ? [value] : [];
+    }),
+  );
+  const dataMaximum = allValues.length > 0 ? Math.max(...allValues) : 1;
+  const maxValue = fixedMaximum ?? Math.max(dataMaximum * 1.12, 1);
+  const firstTimestamp = series[0]?.timestamp;
+  const middleTimestamp = series[Math.floor(series.length / 2)]?.timestamp;
+  const lastTimestamp = series.at(-1)?.timestamp;
+
+  return (
+    <section className={styles.chartCard} aria-label={`${title}: ${description}`}>
+      <header className={styles.chartHeader}>
+        <div>
+          <p className={styles.eyebrow}>{description}</p>
+          <h2>{title}</h2>
+        </div>
+        <div className={styles.chartValue}>{empty ? "—" : valueLabel}</div>
+      </header>
+      <div className={styles.chartFrame} data-loading={empty}>
+        {empty ? <div className={styles.chartSkeleton} aria-hidden="true" /> : null}
+        <svg
+          className={styles.chart}
+          viewBox="0 0 1000 240"
+          preserveAspectRatio="none"
+          role="img"
+          aria-label={`${title} over ${RANGE_LABELS[range]}`}
+        >
+          <title>{`${title} over ${RANGE_LABELS[range]}`}</title>
+          {[32, 91, 150, 210].map((y) => (
+            <line
+              key={y}
+              x1="0"
+              x2="1000"
+              y1={y}
+              y2={y}
+              className={styles.gridLine}
+            />
+          ))}
+          {!empty
+            ? lines.map((line) => (
+                <path
+                  key={line.key}
+                  d={buildLinePath(series, line.key, maxValue)}
+                  fill="none"
+                  stroke={line.color}
+                  strokeWidth="3"
+                  vectorEffect="non-scaling-stroke"
+                  className={styles.metricLine}
+                />
+              ))
+            : null}
+        </svg>
+        <div className={styles.chartAxis} aria-hidden="true">
+          <span>{firstTimestamp ? chartTimestamp(firstTimestamp, range) : "—"}</span>
+          <span>{middleTimestamp ? chartTimestamp(middleTimestamp, range) : "—"}</span>
+          <span>{lastTimestamp ? chartTimestamp(lastTimestamp, range) : "—"}</span>
+        </div>
+      </div>
+      <footer className={styles.legend}>
+        {lines.map((line) => (
+          <span key={line.key}>
+            <i style={{ backgroundColor: line.color }} />
+            {line.label}
+          </span>
+        ))}
+      </footer>
+    </section>
+  );
+}
+
+function KpiCard({
+  detail,
+  icon: IconComponent,
+  label,
+  loading,
+  tone = "neutral",
+  value,
+}: {
+  detail: string;
+  icon: Icon;
+  label: string;
+  loading: boolean;
+  tone?: "neutral" | "good" | "warn" | "bad";
+  value: string;
+}) {
+  return (
+    <article className={styles.kpiCard} data-tone={tone}>
+      <div className={styles.kpiTopline}>
+        <span>{label}</span>
+        <IconComponent aria-hidden="true" />
+      </div>
+      <strong className={loading ? styles.valueSkeleton : undefined}>
+        {loading ? "00.0" : value}
+      </strong>
+      <p>{loading ? "loading Azure signal" : detail}</p>
+    </article>
+  );
+}
+
+function CapacityBar({
+  color,
+  label,
+  loading,
+  value,
+}: {
+  color: string;
+  label: string;
+  loading: boolean;
+  value: number;
+}) {
+  return (
+    <div className={styles.capacityRow}>
+      <div>
+        <span>{label}</span>
+        <strong>{loading ? "—" : `${formatDecimal(value, 1)}%`}</strong>
+      </div>
+      <div className={styles.capacityTrack}>
+        <i
+          style={{
+            backgroundColor: color,
+            width: loading ? "36%" : `${Math.min(100, Math.max(1, value))}%`,
+          }}
+          data-loading={loading}
+        />
+      </div>
+    </div>
+  );
+}
+
+export default function AzureObservabilityDashboard({
+  enabled = true,
+}: {
+  enabled?: boolean;
+}) {
+  const [range, setRange] = useState<AzureMonitorRange>("1h");
+  const [snapshot, setSnapshot] = useState<AzureMonitorSnapshot | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+  const requestId = useRef(0);
+
+  const loadMetrics = useCallback(
+    async (requestedRange: AzureMonitorRange, signal?: AbortSignal) => {
+      const currentRequest = ++requestId.current;
+      setRefreshing(true);
+      setError(null);
+      try {
+        const response = await fetch(
+          `/api/mod/azure-metrics?range=${requestedRange}`,
+          { cache: "no-store", signal },
+        );
+        const body = (await response.json()) as
+          | AzureMonitorSnapshot
+          | { error?: string };
+        if (!response.ok) {
+          throw new Error(
+            "error" in body && body.error
+              ? body.error
+              : "Could not reach Azure Monitor",
+          );
+        }
+        if (currentRequest === requestId.current) {
+          setSnapshot(body as AzureMonitorSnapshot);
+        }
+      } catch (loadError) {
+        if (loadError instanceof Error && loadError.name === "AbortError") return;
+        if (currentRequest === requestId.current) {
+          setError(
+            loadError instanceof Error
+              ? loadError.message
+              : "Could not reach Azure Monitor",
+          );
+        }
+      } finally {
+        if (currentRequest === requestId.current) setRefreshing(false);
+      }
+    },
+    [],
+  );
+
+  useEffect(() => {
+    if (!enabled) return;
+    const controller = new AbortController();
+    void loadMetrics(range, controller.signal);
+    const timer = window.setInterval(() => {
+      if (document.visibilityState === "visible") void loadMetrics(range);
+    }, 30_000);
+
+    return () => {
+      controller.abort();
+      window.clearInterval(timer);
+    };
+  }, [enabled, loadMetrics, range]);
+
+  const data = snapshot?.range === range ? snapshot : null;
+  const loading = data === null;
+  const summary = data?.summary;
+  const healthState = data?.health.state ?? "watch";
+  const serverErrorTone =
+    (summary?.serverErrorRatePercent ?? 0) >= 2
+      ? "bad"
+      : (summary?.serverErrorRatePercent ?? 0) >= 0.5
+        ? "warn"
+        : "good";
+
+  return (
+    <main className={styles.page}>
+      <div className={styles.shell}>
+        <nav className={styles.topbar}>
+          <Link href="/mod" className={styles.backLink}>
+            <ArrowLeft aria-hidden="true" />
+            Control room
+          </Link>
+          <div className={styles.azureMark}>
+            <Cloud aria-hidden="true" />
+            <span>AZURE MONITOR</span>
+          </div>
+          <button
+            type="button"
+            className={styles.refreshButton}
+            onClick={() => void loadMetrics(range)}
+            disabled={refreshing || !enabled}
+          >
+            <RefreshCw aria-hidden="true" data-spinning={refreshing} />
+            Refresh
+          </button>
+        </nav>
+
+        <header className={styles.hero}>
+          <div className={styles.heroCopy}>
+            <div className={styles.liveLabel}>
+              <span /> LIVE TELEMETRY
+            </div>
+            <h1>
+              ExamCooker
+              <em> pulse.</em>
+            </h1>
+            <p>
+              A direct read on requests, reliability and the single B2 worker
+              serving production in South India.
+            </p>
+          </div>
+          <section className={styles.healthPanel} data-state={healthState}>
+            <div className={styles.healthOrb}>
+              <Waves aria-hidden="true" />
+            </div>
+            <div>
+              <span>System condition</span>
+              <strong>{data?.health.label ?? "Establishing signal"}</strong>
+              <p>{data?.health.reasons[0] ?? "Connecting to Azure Monitor"}</p>
+            </div>
+          </section>
+        </header>
+
+        <section className={styles.controlStrip}>
+          <div className={styles.rangePicker} aria-label="Metric time range">
+            {AZURE_MONITOR_RANGES.map((candidate) => (
+              <button
+                type="button"
+                key={candidate}
+                data-active={range === candidate}
+                aria-pressed={range === candidate}
+                onClick={() => setRange(candidate)}
+              >
+                {RANGE_LABELS[candidate]}
+              </button>
+            ))}
+          </div>
+          <div className={styles.freshness}>
+            <Clock3 aria-hidden="true" />
+            <span>
+              {data
+                ? `Updated ${formatUpdatedAt(data.fetchedAt)} · ${formatMetricAge(data.latestMetricAt)}`
+                : "Opening secure Azure stream"}
+            </span>
+          </div>
+        </section>
+
+        {error ? (
+          <div className={styles.errorBanner} role="alert">
+            <Siren aria-hidden="true" />
+            <div>
+              <strong>Azure signal interrupted</strong>
+              <span>{error}. The dashboard will retry automatically.</span>
+            </div>
+          </div>
+        ) : null}
+
+        <section className={styles.kpiGrid}>
+          <KpiCard
+            icon={Activity}
+            label="Average traffic"
+            value={`${formatDecimal(summary?.averageRps ?? 0, 2)} rps`}
+            detail={`${formatCompact(summary?.totalRequests ?? 0)} requests in ${RANGE_LABELS[range]}`}
+            loading={loading}
+          />
+          <KpiCard
+            icon={Gauge}
+            label="Peak traffic"
+            value={`${formatDecimal(summary?.peakRps ?? 0, 1)} rps`}
+            detail={`Highest ${RANGE_COPY[range]} bucket`}
+            loading={loading}
+          />
+          <KpiCard
+            icon={ShieldCheck}
+            label="Server-side success"
+            value={`${formatDecimal(summary?.successRatePercent ?? 0, 2)}%`}
+            detail={`${formatCompact(summary?.serverErrors ?? 0)} server errors observed`}
+            loading={loading}
+            tone={serverErrorTone}
+          />
+          <KpiCard
+            icon={TimerReset}
+            label="Average response"
+            value={formatLatency(summary?.averageResponseTimeMs ?? 0)}
+            detail={`Peak ${formatLatency(summary?.peakResponseTimeMs ?? 0)}`}
+            loading={loading}
+            tone={(summary?.averageResponseTimeMs ?? 0) > 2_000 ? "warn" : "neutral"}
+          />
+        </section>
+
+        <section className={styles.primaryGrid}>
+          <MetricChart
+            title="Request velocity"
+            description="Traffic waveform"
+            range={range}
+            series={data?.series ?? []}
+            lines={[{ key: "rps", label: "Requests / second", color: "#48f0b4" }]}
+            valueLabel={`${formatDecimal(summary?.currentRps ?? 0, 2)} rps now`}
+            empty={loading}
+          />
+          <aside className={styles.capacityCard}>
+            <header>
+              <div>
+                <p className={styles.eyebrow}>Worker headroom</p>
+                <h2>Capacity</h2>
+              </div>
+              <CircleGauge aria-hidden="true" />
+            </header>
+            <div className={styles.machineTag}>
+              <Server aria-hidden="true" />
+              <div>
+                <strong>{data?.resource.sku ?? "B2"} / Linux</strong>
+                <span>
+                  {data?.resource.instanceCount ?? 1} instance · {data?.resource.region ?? "South India"}
+                </span>
+              </div>
+            </div>
+            <CapacityBar
+              label="Average CPU"
+              value={summary?.averageCpuPercent ?? 0}
+              color="#65b5ff"
+              loading={loading}
+            />
+            <CapacityBar
+              label="Average memory"
+              value={summary?.averageMemoryPercent ?? 0}
+              color="#ffb65c"
+              loading={loading}
+            />
+            <CapacityBar
+              label="99.5% SLO error budget used"
+              value={Math.min(
+                100,
+                ((summary?.serverErrorRatePercent ?? 0) /
+                  SERVER_ERROR_BUDGET_PERCENT) *
+                  100,
+              )}
+              color="#ff667c"
+              loading={loading}
+            />
+            <div className={styles.queueReadout}>
+              <DatabaseZap aria-hidden="true" />
+              <span>Peak HTTP queue</span>
+              <strong>{loading ? "—" : formatDecimal(summary?.maxQueueLength ?? 0, 0)}</strong>
+            </div>
+          </aside>
+        </section>
+
+        <section className={styles.chartGrid}>
+          <MetricChart
+            title="Compute pressure"
+            description="App Service plan"
+            range={range}
+            series={data?.series ?? []}
+            lines={[
+              { key: "cpuPercent", label: "CPU", color: "#65b5ff" },
+              { key: "memoryPercent", label: "Memory", color: "#ffb65c" },
+            ]}
+            fixedMaximum={100}
+            valueLabel={`${formatDecimal(summary?.averageCpuPercent ?? 0, 1)}% / ${formatDecimal(summary?.averageMemoryPercent ?? 0, 1)}%`}
+            empty={loading}
+          />
+          <MetricChart
+            title="Server error rate"
+            description="Reliability signal"
+            range={range}
+            series={data?.series ?? []}
+            lines={[
+              { key: "errorRatePercent", label: "HTTP 5xx", color: "#ff667c" },
+            ]}
+            valueLabel={`${formatDecimal(summary?.serverErrorRatePercent ?? 0, 2)}%`}
+            empty={loading}
+          />
+          <MetricChart
+            title="Response time"
+            description="Backend duration"
+            range={range}
+            series={data?.series ?? []}
+            lines={[
+              { key: "responseTimeMs", label: "Average milliseconds", color: "#c59cff" },
+            ]}
+            valueLabel={formatLatency(summary?.averageResponseTimeMs ?? 0)}
+            empty={loading}
+          />
+        </section>
+
+        <section className={styles.statRail}>
+          <div>
+            <Activity aria-hidden="true" />
+            <span>Daily run rate</span>
+            <strong>
+              {loading
+                ? "—"
+                : formatCompact((summary?.averageRps ?? 0) * 86_400)}
+            </strong>
+          </div>
+          <div>
+            <Waves aria-hidden="true" />
+            <span>Burst factor</span>
+            <strong>
+              {loading
+                ? "—"
+                : `${formatDecimal(
+                    (summary?.peakRps ?? 0) /
+                      Math.max(summary?.averageRps ?? 0, 0.01),
+                    1,
+                  )}×`}
+            </strong>
+          </div>
+          <div>
+            <Cpu aria-hidden="true" />
+            <span>Average CPU headroom</span>
+            <strong>
+              {loading
+                ? "—"
+                : `${formatDecimal(100 - (summary?.averageCpuPercent ?? 0), 1)}%`}
+            </strong>
+          </div>
+          <div>
+            <ShieldCheck aria-hidden="true" />
+            <span>99.5% SLO budget left</span>
+            <strong>
+              {loading
+                ? "—"
+                : `${formatDecimal(
+                    Math.max(
+                      0,
+                      100 -
+                        ((summary?.serverErrorRatePercent ?? 0) /
+                          SERVER_ERROR_BUDGET_PERCENT) *
+                          100,
+                    ),
+                    1,
+                  )}%`}
+            </strong>
+          </div>
+        </section>
+
+        <footer className={styles.footer}>
+          <div>
+            <span className={styles.footerPulse} />
+            Secure server-side Azure Resource Manager connection
+          </div>
+          <p>
+            Azure Monitor metrics usually arrive 1–3 minutes late. “Live” reflects
+            the newest published platform sample, not request-level tracing.
+          </p>
+        </footer>
+      </div>
+    </main>
+  );
+}

--- a/app/(mod)/mod/observability/observability.module.css
+++ b/app/(mod)/mod/observability/observability.module.css
@@ -1,0 +1,730 @@
+.page {
+  --obs-bg: #050908;
+  --obs-panel: rgba(13, 21, 18, 0.82);
+  --obs-panel-solid: #0d1512;
+  --obs-line: rgba(205, 241, 224, 0.13);
+  --obs-muted: #8ea198;
+  --obs-text: #edf8f2;
+  --obs-green: #48f0b4;
+  --obs-blue: #65b5ff;
+  --obs-amber: #ffb65c;
+  --obs-red: #ff667c;
+  position: relative;
+  min-height: 100vh;
+  overflow: hidden;
+  color: var(--obs-text);
+  background: var(--obs-bg);
+  font-family: "Plus Jakarta Sans", "Avenir Next", sans-serif;
+}
+
+.shell {
+  position: relative;
+  z-index: 1;
+  width: min(1540px, 100%);
+  margin: 0 auto;
+  padding: 0 34px 42px;
+}
+
+.topbar {
+  min-height: 74px;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  border-bottom: 1px solid var(--obs-line);
+}
+
+.backLink,
+.refreshButton,
+.azureMark {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+
+.backLink {
+  width: fit-content;
+  color: var(--obs-muted);
+  transition: color 160ms ease;
+}
+
+.backLink:hover {
+  color: var(--obs-green);
+}
+
+.backLink svg,
+.refreshButton svg,
+.azureMark svg {
+  width: 16px;
+  height: 16px;
+}
+
+.azureMark {
+  color: #b6c8bf;
+}
+
+.refreshButton {
+  justify-self: end;
+  min-height: 38px;
+  padding: 0 14px;
+  color: var(--obs-text);
+  background: rgba(255, 255, 255, 0.035);
+  border: 1px solid var(--obs-line);
+  border-radius: 2px;
+  cursor: pointer;
+  transition:
+    border-color 160ms ease,
+    background-color 160ms ease;
+}
+
+.refreshButton:hover:not(:disabled) {
+  border-color: rgba(72, 240, 180, 0.55);
+  background: rgba(72, 240, 180, 0.08);
+}
+
+.refreshButton:disabled {
+  cursor: wait;
+  opacity: 0.65;
+}
+
+.refreshButton svg[data-spinning="true"] {
+  animation: obs-spin 1s linear infinite;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(320px, 420px);
+  align-items: end;
+  gap: 40px;
+  padding: 48px 0 36px;
+}
+
+.liveLabel,
+.eyebrow {
+  color: var(--obs-muted);
+  font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+  font-size: 10px !important;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  line-height: 1.4;
+  text-transform: uppercase;
+}
+
+.liveLabel {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  margin-bottom: 18px;
+}
+
+.liveLabel span {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--obs-green);
+}
+
+.hero h1 {
+  max-width: 900px;
+  margin: 0;
+  color: var(--obs-text);
+  font-size: clamp(2.7rem, 5.4vw, 5.6rem);
+  font-weight: 750;
+  letter-spacing: -0.06em;
+  line-height: 0.95;
+}
+
+.hero h1 em {
+  color: var(--obs-green);
+  font-style: normal;
+  font-weight: 500;
+}
+
+.heroCopy > p {
+  max-width: 640px;
+  margin: 30px 0 0;
+  color: #a7b7af;
+  font-size: clamp(13px, 1.4vw, 17px);
+  line-height: 1.75;
+}
+
+.healthPanel {
+  position: relative;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 20px;
+  padding: 22px;
+  overflow: hidden;
+  background: var(--obs-panel-solid);
+  border: 1px solid rgba(72, 240, 180, 0.24);
+  border-radius: 3px;
+}
+
+.healthPanel[data-state="watch"] {
+  background: var(--obs-panel-solid);
+  border-color: rgba(255, 182, 92, 0.28);
+}
+
+.healthPanel[data-state="degraded"] {
+  background: var(--obs-panel-solid);
+  border-color: rgba(255, 102, 124, 0.34);
+}
+
+.healthOrb {
+  display: grid;
+  width: 46px;
+  height: 46px;
+  place-items: center;
+  color: var(--obs-green);
+  border: 1px solid currentColor;
+  border-radius: 50%;
+}
+
+[data-state="watch"] .healthOrb {
+  color: var(--obs-amber);
+}
+
+[data-state="degraded"] .healthOrb {
+  color: var(--obs-red);
+}
+
+.healthOrb svg {
+  width: 21px;
+  height: 21px;
+}
+
+.healthPanel span {
+  display: block;
+  margin-bottom: 5px;
+  color: var(--obs-muted);
+  font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+.healthPanel strong {
+  display: block;
+  color: var(--obs-text);
+  font-size: 20px;
+  letter-spacing: -0.035em;
+}
+
+.healthPanel p {
+  margin: 6px 0 0;
+  color: var(--obs-muted);
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+.controlStrip {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 24px;
+  min-height: 62px;
+  padding: 10px 0;
+  border-top: 1px solid var(--obs-line);
+  border-bottom: 1px solid var(--obs-line);
+}
+
+.rangePicker {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.rangePicker button {
+  min-height: 34px;
+  padding: 0 14px;
+  color: var(--obs-muted);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 2px;
+  font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  cursor: pointer;
+  transition: 150ms ease;
+}
+
+.rangePicker button:hover {
+  color: var(--obs-text);
+}
+
+.rangePicker button[data-active="true"] {
+  color: #06100c;
+  background: var(--obs-green);
+  border-color: var(--obs-green);
+}
+
+.freshness {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--obs-muted);
+  font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+  font-size: 10px;
+  letter-spacing: 0.04em;
+}
+
+.freshness svg {
+  width: 14px;
+  height: 14px;
+  color: var(--obs-green);
+}
+
+.errorBanner {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin-top: 18px;
+  padding: 15px 18px;
+  color: #ffdbe0;
+  background: rgba(255, 102, 124, 0.09);
+  border: 1px solid rgba(255, 102, 124, 0.34);
+  border-radius: 3px;
+}
+
+.errorBanner svg {
+  width: 20px;
+  height: 20px;
+  flex: 0 0 auto;
+  color: var(--obs-red);
+}
+
+.errorBanner strong,
+.errorBanner span {
+  display: block;
+}
+
+.errorBanner strong {
+  font-size: 12px;
+}
+
+.errorBanner span {
+  margin-top: 2px;
+  color: #bb969d;
+  font-size: 10px;
+}
+
+.kpiGrid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1px;
+  margin-top: 28px;
+  background: var(--obs-line);
+  border: 1px solid var(--obs-line);
+}
+
+.kpiCard {
+  position: relative;
+  min-height: 172px;
+  padding: 22px;
+  overflow: hidden;
+  background: rgba(8, 14, 12, 0.96);
+}
+
+.kpiCard::after {
+  content: "";
+  position: absolute;
+  inset: auto 0 0;
+  height: 2px;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.kpiCard[data-tone="good"]::after { background: var(--obs-green); }
+.kpiCard[data-tone="warn"]::after { background: var(--obs-amber); }
+.kpiCard[data-tone="bad"]::after { background: var(--obs-red); }
+
+.kpiTopline {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  color: var(--obs-muted);
+  font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.kpiTopline svg {
+  width: 17px;
+  height: 17px;
+  color: #5e7469;
+}
+
+.kpiCard > strong {
+  display: block;
+  margin-top: 24px;
+  color: var(--obs-text);
+  font-size: clamp(25px, 2.8vw, 42px);
+  font-weight: 650;
+  letter-spacing: -0.06em;
+  line-height: 1;
+}
+
+.kpiCard > p {
+  margin: 12px 0 0;
+  color: var(--obs-muted);
+  font-size: 10px;
+  line-height: 1.5;
+}
+
+.valueSkeleton {
+  width: 62%;
+  color: transparent !important;
+  background: #17261f;
+  border-radius: 2px;
+}
+
+.primaryGrid {
+  display: grid;
+  grid-template-columns: minmax(0, 2.2fr) minmax(300px, 0.8fr);
+  gap: 18px;
+  margin-top: 18px;
+}
+
+.chartGrid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+  margin-top: 18px;
+}
+
+.chartCard,
+.capacityCard {
+  min-width: 0;
+  padding: 22px;
+  background: var(--obs-panel);
+  border: 1px solid var(--obs-line);
+  border-radius: 3px;
+}
+
+.chartHeader,
+.capacityCard > header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 20px;
+}
+
+.chartHeader h2,
+.capacityCard h2 {
+  margin: 6px 0 0;
+  color: var(--obs-text);
+  font-size: 18px;
+  font-weight: 650;
+  letter-spacing: -0.035em;
+}
+
+.chartValue {
+  color: #c8d8d0;
+  font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+  font-size: 11px;
+  font-weight: 600;
+  text-align: right;
+}
+
+.chartFrame {
+  position: relative;
+  min-height: 252px;
+  margin-top: 18px;
+  overflow: hidden;
+}
+
+.chart {
+  width: 100%;
+  height: 218px;
+  overflow: visible;
+}
+
+.gridLine {
+  stroke: rgba(218, 242, 229, 0.09);
+  stroke-width: 1;
+  vector-effect: non-scaling-stroke;
+  stroke-dasharray: 2 5;
+}
+
+.metricLine {
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.chartAxis {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 1px;
+  color: #607269;
+  font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+  font-size: 8px;
+  letter-spacing: 0.04em;
+}
+
+.chartSkeleton {
+  position: absolute;
+  z-index: 2;
+  inset: 8px 0 22px;
+  background: #101a16;
+  border-top: 1px solid rgba(72, 240, 180, 0.12);
+  border-bottom: 1px solid rgba(72, 240, 180, 0.08);
+}
+
+.legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 18px;
+  min-height: 16px;
+  margin-top: 8px;
+  color: var(--obs-muted);
+  font-size: 9px;
+}
+
+.legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.legend i {
+  width: 13px;
+  height: 2px;
+  border-radius: 2px;
+}
+
+.capacityCard > header > svg {
+  width: 24px;
+  height: 24px;
+  color: var(--obs-green);
+}
+
+.machineTag {
+  display: flex;
+  align-items: center;
+  gap: 13px;
+  margin: 25px 0 28px;
+  padding: 14px;
+  background: rgba(72, 240, 180, 0.045);
+  border-left: 2px solid var(--obs-green);
+}
+
+.machineTag svg {
+  width: 19px;
+  height: 19px;
+  color: var(--obs-green);
+}
+
+.machineTag strong,
+.machineTag span {
+  display: block;
+}
+
+.machineTag strong {
+  font-size: 12px;
+  letter-spacing: -0.02em;
+}
+
+.machineTag span {
+  margin-top: 3px;
+  color: var(--obs-muted);
+  font-size: 9px;
+}
+
+.capacityRow + .capacityRow {
+  margin-top: 20px;
+}
+
+.capacityRow > div:first-child {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 8px;
+}
+
+.capacityRow span {
+  color: var(--obs-muted);
+  font-size: 9px;
+}
+
+.capacityRow strong {
+  font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+  font-size: 10px;
+}
+
+.capacityTrack {
+  width: 100%;
+  height: 4px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.07);
+}
+
+.capacityTrack i {
+  display: block;
+  height: 100%;
+  transition: width 500ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.capacityTrack i[data-loading="true"] {
+  opacity: 0.45;
+  animation: obs-bar 1.6s ease-in-out infinite alternate;
+}
+
+.queueReadout {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 10px;
+  margin-top: 27px;
+  padding-top: 19px;
+  border-top: 1px solid var(--obs-line);
+}
+
+.queueReadout svg {
+  width: 16px;
+  height: 16px;
+  color: #71887d;
+}
+
+.queueReadout span {
+  color: var(--obs-muted);
+  font-size: 9px;
+}
+
+.queueReadout strong {
+  font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+  font-size: 14px;
+}
+
+.statRail {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  margin-top: 18px;
+  border: 1px solid var(--obs-line);
+}
+
+.statRail > div {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 11px;
+  min-height: 66px;
+  padding: 0 18px;
+  background: rgba(10, 17, 14, 0.78);
+}
+
+.statRail > div + div {
+  border-left: 1px solid var(--obs-line);
+}
+
+.statRail svg {
+  width: 17px;
+  height: 17px;
+  color: #697f74;
+}
+
+.statRail span {
+  color: var(--obs-muted);
+  font-size: 9px;
+}
+
+.statRail strong {
+  font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+  font-size: 12px;
+}
+
+.footer {
+  display: flex;
+  justify-content: space-between;
+  gap: 32px;
+  padding: 28px 0 0;
+  color: #5f7268;
+  font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+  font-size: 9px;
+  line-height: 1.6;
+}
+
+.footer > div {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  white-space: nowrap;
+}
+
+.footer p {
+  max-width: 560px;
+  margin: 0;
+  font-size: inherit;
+  text-align: right;
+}
+
+.footerPulse {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--obs-green);
+}
+
+@keyframes obs-spin {
+  to { transform: rotate(360deg); }
+}
+
+@keyframes obs-bar {
+  from { width: 18%; }
+  to { width: 58%; }
+}
+
+@media (max-width: 1120px) {
+  .hero { grid-template-columns: 1fr; align-items: start; }
+  .healthPanel { max-width: 560px; }
+  .kpiGrid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .primaryGrid { grid-template-columns: 1fr; }
+  .chartGrid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .chartGrid > :last-child { grid-column: 1 / -1; }
+}
+
+@media (max-width: 760px) {
+  .shell { padding: 0 16px 30px; }
+  .topbar { grid-template-columns: 1fr auto; }
+  .azureMark { display: none; }
+  .hero { gap: 32px; padding: 48px 0 38px; }
+  .hero h1 { font-size: clamp(2.65rem, 12.5vw, 4.2rem); line-height: 0.95; }
+  .controlStrip { align-items: flex-start; flex-direction: column; padding: 13px 0; }
+  .rangePicker { width: 100%; display: grid; grid-template-columns: repeat(4, 1fr); }
+  .rangePicker button { padding: 0 6px; }
+  .kpiGrid { grid-template-columns: 1fr; }
+  .kpiCard { min-height: 150px; }
+  .chartGrid { grid-template-columns: 1fr; }
+  .chartGrid > :last-child { grid-column: auto; }
+  .chartCard, .capacityCard { padding: 18px; }
+  .chartFrame { min-height: 224px; }
+  .chart { height: 194px; }
+  .statRail { grid-template-columns: 1fr 1fr; }
+  .statRail > div + div { border-left: 0; }
+  .statRail > div:nth-child(even) { border-left: 1px solid var(--obs-line); }
+  .statRail > div:nth-child(n + 3) { border-top: 1px solid var(--obs-line); }
+  .footer { align-items: flex-start; flex-direction: column; }
+  .footer p { text-align: left; }
+}
+
+@media (max-width: 420px) {
+  .backLink, .refreshButton { font-size: 9px; }
+  .healthPanel { grid-template-columns: 1fr; }
+  .statRail { grid-template-columns: 1fr; }
+  .statRail > div:nth-child(even) { border-left: 0; }
+  .statRail > div + div { border-top: 1px solid var(--obs-line); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .valueSkeleton,
+  .chartSkeleton,
+  .capacityTrack i,
+  .refreshButton svg {
+    animation: none !important;
+  }
+}

--- a/app/(mod)/mod/observability/page.tsx
+++ b/app/(mod)/mod/observability/page.tsx
@@ -1,0 +1,28 @@
+import type { Metadata } from "next";
+import { notFound, redirect } from "next/navigation";
+import { connection } from "next/server";
+import { Suspense } from "react";
+import { auth } from "@/app/auth";
+import AzureObservabilityDashboard from "./azure-observability-dashboard";
+
+export const metadata: Metadata = {
+  title: "Azure Live | ExamCooker",
+  description: "Private live infrastructure telemetry for ExamCooker.",
+};
+
+async function ProtectedAzureObservabilityDashboard() {
+  await connection();
+  const session = await auth();
+  if (!session?.user) redirect("/");
+  if (session.user.role !== "MODERATOR") notFound();
+
+  return <AzureObservabilityDashboard />;
+}
+
+export default function AzureObservabilityPage() {
+  return (
+    <Suspense fallback={<AzureObservabilityDashboard enabled={false} />}>
+      <ProtectedAzureObservabilityDashboard />
+    </Suspense>
+  );
+}

--- a/app/api/mod/azure-metrics/route.ts
+++ b/app/api/mod/azure-metrics/route.ts
@@ -1,0 +1,36 @@
+import { auth } from "@/app/auth";
+import { getAzureMonitorSnapshot } from "@/lib/azure-monitor";
+import {
+  isAzureMonitorRange,
+  type AzureMonitorRange,
+} from "@/lib/azure-monitor-types";
+
+export async function GET(request: Request) {
+  const session = await auth();
+  if (!session?.user) {
+    return Response.json({ error: "Authentication required" }, { status: 401 });
+  }
+  if (session.user.role !== "MODERATOR") {
+    return Response.json({ error: "Moderator access required" }, { status: 403 });
+  }
+
+  const requestedRange = new URL(request.url).searchParams.get("range");
+  const range: AzureMonitorRange = isAzureMonitorRange(requestedRange)
+    ? requestedRange
+    : "1h";
+
+  try {
+    const snapshot = await getAzureMonitorSnapshot(range);
+    return Response.json(snapshot, {
+      headers: {
+        "Cache-Control": "private, no-store, max-age=0",
+      },
+    });
+  } catch (error) {
+    console.error("[azure-monitor] Failed to load metrics", error);
+    return Response.json(
+      { error: "Azure Monitor is temporarily unavailable" },
+      { status: 502 },
+    );
+  }
+}

--- a/app/components/android-install-banner.tsx
+++ b/app/components/android-install-banner.tsx
@@ -58,7 +58,7 @@ export default function AndroidInstallBanner() {
     const isMobile = useIsMobile();
     const [shouldShow, setShouldShow] = useState(false);
 
-    const isCliPage = pathname === "/cli";
+    const isUtilityPage = pathname === "/cli" || pathname.startsWith("/mod");
     const isAuthPage = pathname === "/auth";
 
     useEffect(() => {
@@ -67,7 +67,7 @@ export default function AndroidInstallBanner() {
         async function checkEligibility() {
             let nextShouldShow = false;
 
-            if (!isMobile || isCliPage || isAuthPage || !isAndroidBrowser()) {
+            if (!isMobile || isUtilityPage || isAuthPage || !isAndroidBrowser()) {
                 return nextShouldShow;
             }
 
@@ -96,7 +96,7 @@ export default function AndroidInstallBanner() {
         return () => {
             cancelled = true;
         };
-    }, [isAuthPage, isCliPage, isMobile]);
+    }, [isAuthPage, isUtilityPage, isMobile]);
 
     if (!shouldShow) return null;
 

--- a/app/components/moderator-dash-board.tsx
+++ b/app/components/moderator-dash-board.tsx
@@ -427,6 +427,12 @@ const ModeratorDashboardClient: React.FC<ModeratorDashboardClientProps> = ({
                 >
                     Review note courses →
                 </Link>
+                <Link
+                    href="/mod/observability"
+                    className="border-2 border-black bg-[#5FC4E7] px-4 py-2 text-sm font-semibold text-black transition hover:translate-x-[-2px] hover:translate-y-[-2px] dark:border-[#3BF4C7] dark:bg-[#3BF4C7]/10 dark:text-[#3BF4C7]"
+                >
+                    Azure live metrics →
+                </Link>
             </div>
             <br />
             <div className="w-full flex justify-center mb-6">

--- a/app/components/ui/upsell-modal.tsx
+++ b/app/components/ui/upsell-modal.tsx
@@ -54,11 +54,11 @@ const UpsellModal = () => {
     const isMobile = useIsMobile();
     const [phase, dispatchPhase] = useReducer(modalPhaseReducer, "idle");
 
-    const isCliPage = pathname === "/cli";
+    const isUtilityPage = pathname === "/cli" || pathname.startsWith("/mod");
     const isAuthPage = pathname === "/auth";
 
     useEffect(() => {
-        if (isCliPage || isAuthPage || isMobile) {
+        if (isUtilityPage || isAuthPage || isMobile) {
             dispatchPhase("closed");
             return;
         }
@@ -68,7 +68,7 @@ const UpsellModal = () => {
         }
         const timer = window.setTimeout(() => dispatchPhase("entering"), MODAL_SHOW_DELAY_MS);
         return () => window.clearTimeout(timer);
-    }, [isAuthPage, isCliPage, isMobile]);
+    }, [isAuthPage, isUtilityPage, isMobile]);
 
     useEffect(() => {
         if (phase === "entering") {
@@ -88,7 +88,7 @@ const UpsellModal = () => {
     const isVisible = phase === "open";
     const isRendered = phase !== "idle" && phase !== "closed";
 
-    if (isCliPage || isAuthPage || isMobile || !isRendered) return null;
+    if (isUtilityPage || isAuthPage || isMobile || !isRendered) return null;
 
     return (
         <div

--- a/app/components/ui/upsell-toast.tsx
+++ b/app/components/ui/upsell-toast.tsx
@@ -59,7 +59,7 @@ const UpsellToast = () => {
 
     upsellRef.current = upsell;
 
-    const isCliPage = pathname === "/cli";
+    const isUtilityPage = pathname === "/cli" || pathname.startsWith("/mod");
     const isAuthPage = pathname === "/auth";
 
     const hideToast = useCallback(() => {
@@ -86,14 +86,14 @@ const UpsellToast = () => {
     }, []);
 
     useEffect(() => {
-        if (isCliPage || isAuthPage || isMobile) return;
+        if (isUtilityPage || isAuthPage || isMobile) return;
         const next = pickNextUpsell();
         if (!next) return;
         const timer = window.setTimeout(() => {
             dispatch({ type: "mount", upsell: next });
         }, UPSELL_SHOW_DELAY_MS);
         return () => window.clearTimeout(timer);
-    }, [isAuthPage, isCliPage, isMobile]);
+    }, [isAuthPage, isUtilityPage, isMobile]);
 
     useEffect(() => {
         if (!mounted) return;
@@ -104,9 +104,9 @@ const UpsellToast = () => {
     }, [mounted]);
 
     useEffect(() => {
-        if (!isCliPage && !isAuthPage && !isMobile) return;
+        if (!isUtilityPage && !isAuthPage && !isMobile) return;
         dispatch({ type: "reset" });
-    }, [isAuthPage, isCliPage, isMobile]);
+    }, [isAuthPage, isUtilityPage, isMobile]);
 
     useEffect(() => {
         if (!visible || !upsell) return;
@@ -114,7 +114,7 @@ const UpsellToast = () => {
         return () => window.clearTimeout(timer);
     }, [visible, upsell?.id, hideToast]);
 
-    if (isCliPage || isAuthPage || isMobile || !mounted || !upsell) return null;
+    if (isUtilityPage || isAuthPage || isMobile || !mounted || !upsell) return null;
 
     const handleLinkCtaClick = () => {
         markUpsellDismissed(upsell.id);

--- a/lib/azure-monitor-types.ts
+++ b/lib/azure-monitor-types.ts
@@ -1,0 +1,62 @@
+export const AZURE_MONITOR_RANGES = ["1h", "24h", "7d", "30d"] as const;
+
+export type AzureMonitorRange = (typeof AZURE_MONITOR_RANGES)[number];
+
+export type AzureMonitorPoint = {
+  timestamp: string;
+  rps: number | null;
+  requests: number | null;
+  cpuPercent: number | null;
+  memoryPercent: number | null;
+  responseTimeMs: number | null;
+  serverErrors: number | null;
+  clientErrors: number | null;
+  errorRatePercent: number | null;
+  queueLength: number | null;
+  workingSetGiB: number | null;
+};
+
+export type AzureMonitorSnapshot = {
+  range: AzureMonitorRange;
+  intervalSeconds: number;
+  fetchedAt: string;
+  latestMetricAt: string | null;
+  resource: {
+    appName: string;
+    planName: string;
+    region: string;
+    sku: string;
+    instanceCount: number;
+  };
+  health: {
+    state: "healthy" | "watch" | "degraded";
+    label: string;
+    reasons: string[];
+  };
+  summary: {
+    totalRequests: number;
+    averageRps: number;
+    peakRps: number;
+    averageCpuPercent: number;
+    peakCpuPercent: number;
+    averageMemoryPercent: number;
+    peakMemoryPercent: number;
+    averageResponseTimeMs: number;
+    peakResponseTimeMs: number;
+    serverErrors: number;
+    serverErrorRatePercent: number;
+    clientErrors: number;
+    successRatePercent: number;
+    maxQueueLength: number;
+    currentRps: number;
+    currentCpuPercent: number;
+    currentMemoryPercent: number;
+  };
+  series: AzureMonitorPoint[];
+};
+
+export function isAzureMonitorRange(
+  value: string | null,
+): value is AzureMonitorRange {
+  return AZURE_MONITOR_RANGES.includes(value as AzureMonitorRange);
+}

--- a/lib/azure-monitor.ts
+++ b/lib/azure-monitor.ts
@@ -1,0 +1,411 @@
+import "server-only";
+
+import { DefaultAzureCredential } from "@azure/identity";
+import type {
+  AzureMonitorPoint,
+  AzureMonitorRange,
+  AzureMonitorSnapshot,
+} from "@/lib/azure-monitor-types";
+
+const ARM_SCOPE = "https://management.azure.com/.default";
+const ARM_ORIGIN = "https://management.azure.com";
+const METRICS_API_VERSION = "2023-10-01";
+const REQUEST_TIMEOUT_MS = 15_000;
+
+const RANGE_CONFIG: Record<
+  AzureMonitorRange,
+  { durationMs: number; interval: string; intervalSeconds: number }
+> = {
+  "1h": { durationMs: 60 * 60 * 1_000, interval: "PT1M", intervalSeconds: 60 },
+  "24h": {
+    durationMs: 24 * 60 * 60 * 1_000,
+    interval: "PT5M",
+    intervalSeconds: 5 * 60,
+  },
+  "7d": {
+    durationMs: 7 * 24 * 60 * 60 * 1_000,
+    interval: "PT1H",
+    intervalSeconds: 60 * 60,
+  },
+  "30d": {
+    durationMs: 30 * 24 * 60 * 60 * 1_000,
+    interval: "PT6H",
+    intervalSeconds: 6 * 60 * 60,
+  },
+};
+
+type AzureMetricDatum = {
+  timeStamp: string;
+  average?: number;
+  maximum?: number;
+  total?: number;
+};
+
+type AzureMetricResponse = {
+  interval?: string;
+  value?: Array<{
+    name?: { value?: string };
+    timeseries?: Array<{ data?: AzureMetricDatum[] }>;
+  }>;
+};
+
+type Aggregation = "average" | "maximum" | "total";
+
+let credential: DefaultAzureCredential | null = null;
+
+function requiredEnvironmentValue(name: string) {
+  const value = process.env[name]?.trim();
+  if (!value) {
+    throw new Error(`Missing Azure Monitor configuration: ${name}`);
+  }
+  return value;
+}
+
+function azureConfiguration() {
+  const subscriptionId = requiredEnvironmentValue("AZURE_SUBSCRIPTION_ID");
+  const resourceGroup =
+    process.env.AZURE_RESOURCE_GROUP?.trim() || "rg-examcooker-prod";
+  const appName =
+    process.env.AZURE_WEBAPP_NAME?.trim() || "examcooker-2024";
+  const planName =
+    process.env.AZURE_APP_SERVICE_PLAN_NAME?.trim() ||
+    "asp-examcooker-b3-southindia";
+
+  const resourceGroupPath = `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}`;
+  return {
+    appName,
+    planName,
+    region: process.env.AZURE_APP_SERVICE_REGION?.trim() || "South India",
+    sku: process.env.AZURE_APP_SERVICE_SKU?.trim() || "B2",
+    instanceCount: Number(process.env.AZURE_APP_SERVICE_INSTANCES || "1"),
+    appResourceId: `${resourceGroupPath}/providers/Microsoft.Web/sites/${appName}`,
+    planResourceId: `${resourceGroupPath}/providers/Microsoft.Web/serverfarms/${planName}`,
+  };
+}
+
+function getCredential() {
+  credential ??= new DefaultAzureCredential();
+  return credential;
+}
+
+async function fetchAzureMetrics(input: {
+  accessToken: string;
+  aggregation: string;
+  end: Date;
+  interval: string;
+  metricNames: string[];
+  resourceId: string;
+  start: Date;
+}) {
+  const url = new URL(
+    `${ARM_ORIGIN}${input.resourceId}/providers/Microsoft.Insights/metrics`,
+  );
+  url.searchParams.set("api-version", METRICS_API_VERSION);
+  url.searchParams.set(
+    "timespan",
+    `${input.start.toISOString()}/${input.end.toISOString()}`,
+  );
+  url.searchParams.set("interval", input.interval);
+  url.searchParams.set("metricnames", input.metricNames.join(","));
+  url.searchParams.set("aggregation", input.aggregation);
+  url.searchParams.set("AutoAdjustTimegrain", "true");
+  url.searchParams.set("ValidateDimensions", "false");
+
+  const response = await fetch(url, {
+    cache: "no-store",
+    headers: { Authorization: `Bearer ${input.accessToken}` },
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+
+  if (!response.ok) {
+    const detail = await response.text();
+    throw new Error(
+      `Azure Monitor request failed (${response.status}): ${detail.slice(0, 240)}`,
+    );
+  }
+
+  return (await response.json()) as AzureMetricResponse;
+}
+
+function metricValues(
+  response: AzureMetricResponse,
+  metricName: string,
+  aggregation: Aggregation,
+) {
+  const points = new Map<string, number[]>();
+  const metric = response.value?.find(
+    (candidate) => candidate.name?.value === metricName,
+  );
+
+  for (const series of metric?.timeseries ?? []) {
+    for (const datum of series.data ?? []) {
+      const value = datum[aggregation];
+      if (typeof value !== "number" || !Number.isFinite(value)) continue;
+      const existing = points.get(datum.timeStamp) ?? [];
+      existing.push(value);
+      points.set(datum.timeStamp, existing);
+    }
+  }
+
+  const result = new Map<string, number>();
+  for (const [timestamp, values] of points) {
+    const value =
+      aggregation === "total"
+        ? values.reduce((sum, candidate) => sum + candidate, 0)
+        : aggregation === "maximum"
+          ? Math.max(...values)
+          : values.reduce((sum, candidate) => sum + candidate, 0) /
+            values.length;
+    result.set(timestamp, value);
+  }
+  return result;
+}
+
+function finiteValues(values: Array<number | null>) {
+  return values.filter(
+    (value): value is number => typeof value === "number" && Number.isFinite(value),
+  );
+}
+
+function average(values: Array<number | null>) {
+  const valid = finiteValues(values);
+  return valid.length > 0
+    ? valid.reduce((sum, value) => sum + value, 0) / valid.length
+    : 0;
+}
+
+function maximum(values: Array<number | null>) {
+  const valid = finiteValues(values);
+  return valid.length > 0 ? Math.max(...valid) : 0;
+}
+
+function total(values: Array<number | null>) {
+  return finiteValues(values).reduce((sum, value) => sum + value, 0);
+}
+
+function lastValue(values: Array<number | null>) {
+  for (let index = values.length - 1; index >= 0; index -= 1) {
+    const value = values[index];
+    if (typeof value === "number" && Number.isFinite(value)) return value;
+  }
+  return 0;
+}
+
+function round(value: number, precision = 2) {
+  const factor = 10 ** precision;
+  return Math.round(value * factor) / factor;
+}
+
+function deriveHealth(summary: AzureMonitorSnapshot["summary"]) {
+  const degradedReasons: string[] = [];
+  const watchReasons: string[] = [];
+
+  if (summary.serverErrorRatePercent >= 2) {
+    degradedReasons.push(
+      `${round(summary.serverErrorRatePercent, 1)}% server error rate`,
+    );
+  } else if (summary.serverErrorRatePercent >= 0.5) {
+    watchReasons.push(
+      `${round(summary.serverErrorRatePercent, 1)}% server error rate`,
+    );
+  }
+
+  if (summary.averageMemoryPercent >= 90 || summary.maxQueueLength > 5) {
+    degradedReasons.push(
+      summary.maxQueueLength > 5
+        ? `HTTP queue reached ${round(summary.maxQueueLength, 0)}`
+        : `${round(summary.averageMemoryPercent, 0)}% average memory`,
+    );
+  } else if (
+    summary.averageMemoryPercent >= 80 ||
+    summary.peakCpuPercent >= 95 ||
+    summary.maxQueueLength > 0
+  ) {
+    watchReasons.push(
+      summary.averageMemoryPercent >= 80
+        ? `${round(summary.averageMemoryPercent, 0)}% average memory`
+        : summary.maxQueueLength > 0
+          ? `HTTP queue reached ${round(summary.maxQueueLength, 0)}`
+          : `${round(summary.peakCpuPercent, 0)}% peak CPU`,
+    );
+  }
+
+  if (degradedReasons.length > 0) {
+    return {
+      state: "degraded" as const,
+      label: "Degraded",
+      reasons: [...degradedReasons, ...watchReasons],
+    };
+  }
+  if (watchReasons.length > 0) {
+    return {
+      state: "watch" as const,
+      label: "Needs attention",
+      reasons: watchReasons,
+    };
+  }
+  return {
+    state: "healthy" as const,
+    label: "Operating normally",
+    reasons: ["No capacity queue or elevated server-error signal"],
+  };
+}
+
+export async function getAzureMonitorSnapshot(
+  range: AzureMonitorRange,
+): Promise<AzureMonitorSnapshot> {
+  const config = azureConfiguration();
+  const rangeConfig = RANGE_CONFIG[range];
+  const end = new Date();
+  const start = new Date(end.getTime() - rangeConfig.durationMs);
+  const token = await getCredential().getToken(ARM_SCOPE);
+  if (!token?.token) throw new Error("Azure identity did not return an access token");
+
+  const [appMetrics, planMetrics] = await Promise.all([
+    fetchAzureMetrics({
+      accessToken: token.token,
+      aggregation: "Total,Average,Maximum",
+      end,
+      interval: rangeConfig.interval,
+      metricNames: [
+        "Requests",
+        "Http2xx",
+        "Http4xx",
+        "Http5xx",
+        "HttpResponseTime",
+        "MemoryWorkingSet",
+      ],
+      resourceId: config.appResourceId,
+      start,
+    }),
+    fetchAzureMetrics({
+      accessToken: token.token,
+      aggregation: "Average,Maximum",
+      end,
+      interval: rangeConfig.interval,
+      metricNames: ["CpuPercentage", "MemoryPercentage", "HttpQueueLength"],
+      resourceId: config.planResourceId,
+      start,
+    }),
+  ]);
+
+  const requests = metricValues(appMetrics, "Requests", "total");
+  const serverErrors = metricValues(appMetrics, "Http5xx", "total");
+  const clientErrors = metricValues(appMetrics, "Http4xx", "total");
+  const responseTimes = metricValues(appMetrics, "HttpResponseTime", "average");
+  const responseTimePeaks = metricValues(appMetrics, "HttpResponseTime", "maximum");
+  const workingSet = metricValues(appMetrics, "MemoryWorkingSet", "average");
+  const cpu = metricValues(planMetrics, "CpuPercentage", "average");
+  const cpuPeaks = metricValues(planMetrics, "CpuPercentage", "maximum");
+  const memory = metricValues(planMetrics, "MemoryPercentage", "average");
+  const memoryPeaks = metricValues(planMetrics, "MemoryPercentage", "maximum");
+  const queue = metricValues(planMetrics, "HttpQueueLength", "average");
+  const queuePeaks = metricValues(planMetrics, "HttpQueueLength", "maximum");
+
+  const timestamps = Array.from(
+    new Set([
+      ...requests.keys(),
+      ...serverErrors.keys(),
+      ...cpu.keys(),
+      ...memory.keys(),
+      ...responseTimes.keys(),
+    ]),
+  ).sort();
+
+  const series: AzureMonitorPoint[] = timestamps.map((timestamp) => {
+    const requestCount = requests.get(timestamp) ?? null;
+    const serverErrorCount = serverErrors.get(timestamp) ?? null;
+    return {
+      timestamp,
+      requests: requestCount,
+      rps:
+        requestCount === null
+          ? null
+          : requestCount / rangeConfig.intervalSeconds,
+      cpuPercent: cpu.get(timestamp) ?? null,
+      memoryPercent: memory.get(timestamp) ?? null,
+      responseTimeMs:
+        responseTimes.has(timestamp)
+          ? (responseTimes.get(timestamp) ?? 0) * 1_000
+          : null,
+      serverErrors: serverErrorCount,
+      clientErrors: clientErrors.get(timestamp) ?? null,
+      errorRatePercent:
+        requestCount && serverErrorCount !== null
+          ? (serverErrorCount / requestCount) * 100
+          : requestCount === 0
+            ? 0
+            : null,
+      queueLength: queue.get(timestamp) ?? null,
+      workingSetGiB:
+        workingSet.has(timestamp)
+          ? (workingSet.get(timestamp) ?? 0) / 1_073_741_824
+          : null,
+    };
+  });
+
+  const totalRequests = total(series.map((point) => point.requests));
+  const totalServerErrors = total(series.map((point) => point.serverErrors));
+  const elapsedSeconds = rangeConfig.durationMs / 1_000;
+  const summary: AzureMonitorSnapshot["summary"] = {
+    totalRequests: round(totalRequests, 0),
+    averageRps: round(totalRequests / elapsedSeconds, 2),
+    peakRps: round(maximum(series.map((point) => point.rps)), 2),
+    averageCpuPercent: round(average(series.map((point) => point.cpuPercent)), 1),
+    peakCpuPercent: round(maximum(Array.from(cpuPeaks.values())), 1),
+    averageMemoryPercent: round(
+      average(series.map((point) => point.memoryPercent)),
+      1,
+    ),
+    peakMemoryPercent: round(maximum(Array.from(memoryPeaks.values())), 1),
+    averageResponseTimeMs: round(
+      average(series.map((point) => point.responseTimeMs)),
+      0,
+    ),
+    peakResponseTimeMs: round(
+      maximum(Array.from(responseTimePeaks.values())) * 1_000,
+      0,
+    ),
+    serverErrors: round(totalServerErrors, 0),
+    serverErrorRatePercent: round(
+      totalRequests > 0 ? (totalServerErrors / totalRequests) * 100 : 0,
+      2,
+    ),
+    clientErrors: round(total(series.map((point) => point.clientErrors)), 0),
+    successRatePercent: round(
+      totalRequests > 0
+        ? ((totalRequests - totalServerErrors) / totalRequests) * 100
+        : 100,
+      2,
+    ),
+    maxQueueLength: round(maximum(Array.from(queuePeaks.values())), 1),
+    currentRps: round(lastValue(series.map((point) => point.rps)), 2),
+    currentCpuPercent: round(
+      lastValue(series.map((point) => point.cpuPercent)),
+      1,
+    ),
+    currentMemoryPercent: round(
+      lastValue(series.map((point) => point.memoryPercent)),
+      1,
+    ),
+  };
+
+  return {
+    range,
+    intervalSeconds: rangeConfig.intervalSeconds,
+    fetchedAt: end.toISOString(),
+    latestMetricAt: timestamps.at(-1) ?? null,
+    resource: {
+      appName: config.appName,
+      planName: config.planName,
+      region: config.region,
+      sku: config.sku,
+      instanceCount: Number.isFinite(config.instanceCount)
+        ? config.instanceCount
+        : 1,
+    },
+    health: deriveHealth(summary),
+    summary,
+    series,
+  };
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -132,7 +132,7 @@ const nextConfig: NextConfig = {
             },
         },
     },
-    serverExternalPackages: ["canvas"],
+    serverExternalPackages: ["@azure/identity", "canvas"],
     images: {
         formats: ["image/avif", "image/webp"],
         minimumCacheTTL: 60 * 60 * 24 * 30,

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "@ai-sdk/openai": "^4.0.29",
+    "@azure/identity": "^4.13.1",
     "@azure/storage-blob": "^12.33.0",
     "@capacitor/android": "^8.5.0",
     "@capacitor/app": "^8.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       '@ai-sdk/openai':
         specifier: ^4.0.29
         version: 4.0.29(zod@4.4.3)
+      '@azure/identity':
+        specifier: ^4.13.1
+        version: 4.13.1(supports-color@10.2.2)
       '@azure/storage-blob':
         specifier: ^12.33.0
         version: 12.33.0(supports-color@10.2.2)


### PR DESCRIPTION
## What changed
- adds a moderator-only Azure App Service observability dashboard
- streams live request, error, response-time, CPU, memory, and queue metrics from Azure Monitor
- adds 1h, 24h, 7d, and 30d ranges with 30-second refreshes
- uses App Service managed identity so Azure credentials never reach the browser
- keeps moderator utility pages free of promotional overlays

## UI
- flat, minimal dark interface with no gradients
- responsive charts and benchmark summaries
- partial-prerendered shell instead of a blocking spinner

## Validation
- `pnpm exec tsc --noEmit`
- `pnpm build`
- live Azure Monitor queries for every range
- desktop and mobile visual QA with no overflow or console errors
- anonymous access redirects away; moderator API access is enforced

<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

Adds a moderator-only Azure observability dashboard, including server-side metric retrieval, health summaries, charts, refresh behavior, and moderator navigation.

The metric snapshot path was exercised with multi-series responses: aggregation, timestamps, and response-time conversion work when Azure accepts the request. However, the App Service request combines metric aggregations that Azure can reject for the requested heterogeneous metric set, causing the dashboard API to return 502 instead of telemetry.

<h3>Confidence Score: 4/5</h3>

Not ready to merge until Azure metric requests are split into aggregation-compatible groups.

There is one independent non-security P1 finding: Azure Monitor can reject the combined App Service metrics request, preventing the dashboard from loading. Under the scoring table, one non-security P1 yields a score of 4.

**Files Needing Attention:** lib/azure-monitor.ts needs the App Service metric requests and aggregation handling revised.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced proof for the posted P1 finding.
- T-Rex reviewed the corresponding review comment to validate the P1 finding details.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22acm-vit%2Fexamcooker%22%20on%20the%20existing%20branch%20%22dev%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22dev%22.%0A%0A%23%23%23%20Issue%201%0Alib%2Fazure-monitor.ts%3A267-278%0A**Mixed%20metric%20aggregations%20break%20Azure%20Monitor%20retrieval**%0A%0AThe%20App%20Service%20request%20asks%20for%20%60Total%2CAverage%2CMaximum%60%20across%20request%20counts%2C%20HTTP%20response%20time%2C%20and%20memory%20in%20one%20call.%20These%20metrics%20do%20not%20share%20the%20same%20supported%20aggregations%2C%20so%20Azure%20Monitor%20can%20reject%20the%20complete%20request%20with%20HTTP%20400.%20That%20error%20propagates%20to%20the%20route%20as%20a%20502%2C%20leaving%20the%20moderator%20dashboard%20unable%20to%20display%20any%20telemetry.%20Fetch%20compatible%20metric%20groups%20separately%20and%20request%20only%20aggregations%20supported%20by%20each%20metric.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=acm-vit%2Fexamcooker&pr=525&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Alib%2Fazure-monitor.ts%3A267-278%0A**Mixed%20metric%20aggregations%20break%20Azure%20Monitor%20retrieval**%0A%0AThe%20App%20Service%20request%20asks%20for%20%60Total%2CAverage%2CMaximum%60%20across%20request%20counts%2C%20HTTP%20response%20time%2C%20and%20memory%20in%20one%20call.%20These%20metrics%20do%20not%20share%20the%20same%20supported%20aggregations%2C%20so%20Azure%20Monitor%20can%20reject%20the%20complete%20request%20with%20HTTP%20400.%20That%20error%20propagates%20to%20the%20route%20as%20a%20502%2C%20leaving%20the%20moderator%20dashboard%20unable%20to%20display%20any%20telemetry.%20Fetch%20compatible%20metric%20groups%20separately%20and%20request%20only%20aggregations%20supported%20by%20each%20metric.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=acm-vit%2Fexamcooker&pr=525&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Alib%2Fazure-monitor.ts%3A267-278%0A**Mixed%20metric%20aggregations%20break%20Azure%20Monitor%20retrieval**%0A%0AThe%20App%20Service%20request%20asks%20for%20%60Total%2CAverage%2CMaximum%60%20across%20request%20counts%2C%20HTTP%20response%20time%2C%20and%20memory%20in%20one%20call.%20These%20metrics%20do%20not%20share%20the%20same%20supported%20aggregations%2C%20so%20Azure%20Monitor%20can%20reject%20the%20complete%20request%20with%20HTTP%20400.%20That%20error%20propagates%20to%20the%20route%20as%20a%20502%2C%20leaving%20the%20moderator%20dashboard%20unable%20to%20display%20any%20telemetry.%20Fetch%20compatible%20metric%20groups%20separately%20and%20request%20only%20aggregations%20supported%20by%20each%20metric.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=525&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat: add live Azure observability dashb..."](https://github.com/acm-vit/examcooker/commit/1393c5d976812d2d4309e1eb536209d758008166) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51316971)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->