### PR TITLE
feat: expand Azure dashboard metrics

### DIFF
--- a/app/(mod)/mod/observability/azure-observability-dashboard.tsx
+++ b/app/(mod)/mod/observability/azure-observability-dashboard.tsx
@@ -11,7 +11,6 @@ import {
   Server,
   ShieldCheck,
   TimerReset,
-  Waves,
 } from "lucide-react";
 import {
   type ComponentType,
@@ -52,6 +51,9 @@ type MetricKey = keyof Pick<
   | "errorRatePercent"
   | "bytesReceivedMiB"
   | "bytesSentMiB"
+  | "workingSetGiB"
+  | "ioReadMiBPerSecond"
+  | "diskQueueLength"
 >;
 
 type ChartLine = {
@@ -61,10 +63,19 @@ type ChartLine = {
 };
 
 function formatCompact(value: number, digits = 1) {
-  return new Intl.NumberFormat("en-IN", {
+  return new Intl.NumberFormat("en-US", {
     maximumFractionDigits: digits,
     notation: Math.abs(value) >= 1_000 ? "compact" : "standard",
   }).format(value);
+}
+
+function formatCount(value: number) {
+  if (Math.abs(value) >= 100_000) {
+    return `${new Intl.NumberFormat("en-US", {
+      maximumFractionDigits: Math.abs(value) >= 10_000_000 ? 1 : 2,
+    }).format(value / 1_000_000)}M`;
+  }
+  return formatCompact(value);
 }
 
 function formatDecimal(value: number, digits = 1) {
@@ -77,6 +88,16 @@ function formatDecimal(value: number, digits = 1) {
 function formatLatency(valueMs: number) {
   if (valueMs >= 1_000) return `${formatDecimal(valueMs / 1_000, 2)} s`;
   return `${formatCompact(valueMs, 0)} ms`;
+}
+
+function formatDuration(valueSeconds: number) {
+  if (valueSeconds >= 3_600) {
+    return `${formatDecimal(valueSeconds / 3_600, 1)} h`;
+  }
+  if (valueSeconds >= 60) {
+    return `${formatDecimal(valueSeconds / 60, 1)} min`;
+  }
+  return `${formatDecimal(valueSeconds, 1)} s`;
 }
 
 function formatAge(timestamp: string | null) {
@@ -179,35 +200,10 @@ function MetricCard({
           </strong>
         )}
         <p className="mt-2 text-xs leading-5 text-black/60 dark:text-[#D5D5D5]/55">
-          {loading ? "Reading Azure Monitor" : detail}
+          {loading ? "Loading" : detail}
         </p>
       </div>
     </article>
-  );
-}
-
-function InlineStat({
-  label,
-  loading,
-  value,
-}: {
-  label: string;
-  loading: boolean;
-  value: string;
-}) {
-  return (
-    <div className="flex min-w-0 flex-col items-start gap-0.5 text-left sm:flex-row sm:items-baseline sm:gap-1.5">
-      {loading ? (
-        <span className="block h-7 w-16 animate-pulse bg-black/10 dark:bg-white/10 sm:h-5" />
-      ) : (
-        <span className="text-[1.7rem] font-black leading-none text-black dark:text-[#D5D5D5] sm:text-xl">
-          {value}
-        </span>
-      )}
-      <span className="text-[10px] font-semibold uppercase tracking-[0.12em] text-black/60 dark:text-[#D5D5D5]/60 sm:text-xs sm:tracking-wider">
-        {label}
-      </span>
-    </div>
   );
 }
 
@@ -411,22 +407,21 @@ export default function AzureObservabilityDashboard({
   const data = snapshot?.range === range ? snapshot : null;
   const summary = data?.summary;
   const loading = !data;
-  const healthClasses =
+  const healthDotClass =
     data?.health.state === "degraded"
-      ? "border-red-500 bg-red-500/10"
+      ? "bg-red-500"
       : data?.health.state === "watch"
-        ? "border-amber-500 bg-amber-500/10"
-        : "border-[#253EE0] bg-[#5FC4E7]/25 dark:border-[#3BF4C7] dark:bg-[#3BF4C7]/10";
-  const projectedDailyRequests = (summary?.averageRpm ?? 0) * 1_440;
+        ? "bg-amber-500"
+        : "bg-[#253EE0] dark:bg-[#3BF4C7]";
 
   return (
     <div className="min-h-dvh bg-[#C2E6EC] text-black transition-colors dark:bg-[hsl(224,48%,9%)] dark:text-[#D5D5D5]">
-      <div className="mx-auto flex w-full max-w-7xl flex-col gap-10 px-3 py-6 sm:px-6 sm:py-8 lg:gap-12 lg:px-10 lg:py-12">
-        <header>
-          <div className="mb-8 flex items-center justify-between gap-3">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-10 px-3 py-6 sm:px-6 sm:py-8 lg:px-10 lg:py-10">
+        <header className="border-b-2 border-black/20 pb-5 dark:border-white/20">
+          <div className="flex items-center justify-between gap-3">
             <Link
               href="/mod"
-              className="inline-flex h-10 items-center gap-2 border-2 border-black/25 px-3 text-sm font-semibold transition hover:border-black dark:border-white/25 dark:hover:border-white"
+              className="inline-flex h-9 items-center gap-2 text-sm font-semibold text-black/65 transition hover:text-black dark:text-[#D5D5D5]/65 dark:hover:text-[#D5D5D5]"
             >
               <ArrowLeft className="size-4" aria-hidden />
               Moderator
@@ -435,7 +430,7 @@ export default function AzureObservabilityDashboard({
               type="button"
               onClick={() => void loadMetrics(range)}
               disabled={refreshing || !enabled}
-              className="inline-flex h-10 items-center gap-2 border-2 border-black bg-[#5FC4E7] px-3 text-sm font-bold text-black transition hover:bg-[#71cdec] disabled:cursor-wait disabled:opacity-60 dark:border-[#5FC4E7] dark:bg-[#5FC4E7]/15 dark:text-[#D5D5D5]"
+              className="inline-flex h-9 items-center gap-2 border border-black/30 px-3 text-xs font-bold uppercase tracking-wide transition hover:border-black disabled:cursor-wait disabled:opacity-60 dark:border-white/30 dark:hover:border-white"
             >
               <RefreshCw
                 className={`size-4 ${refreshing ? "animate-spin" : ""}`}
@@ -445,64 +440,22 @@ export default function AzureObservabilityDashboard({
             </button>
           </div>
 
-          <div className="grid gap-7 lg:grid-cols-[minmax(0,1fr)_22rem] lg:items-end">
+          <div className="mt-5 flex flex-col justify-between gap-3 sm:flex-row sm:items-end">
             <div>
-              <p className="mb-3 font-mono text-xs font-bold uppercase tracking-[0.16em] text-black/60 dark:text-[#D5D5D5]/60">
-                Production · Azure App Service
+              <p className="mb-1 font-mono text-[11px] font-bold uppercase tracking-[0.14em] text-black/55 dark:text-[#D5D5D5]/55">
+                Production · {data?.resource.sku ?? "B2"} · {data?.resource.region ?? "South India"}
               </p>
-              <h1 className="max-w-4xl text-4xl font-extrabold leading-[1.02] sm:text-5xl md:text-6xl lg:text-7xl">
-                Production. <span className="text-[#253EE0] dark:text-[#5FC4E7]">Live.</span>
+              <h1 className="text-3xl font-extrabold leading-tight sm:text-4xl">
+                Azure metrics
               </h1>
-              <p className="mt-4 max-w-2xl text-sm leading-6 text-black/65 dark:text-[#D5D5D5]/65 sm:text-base">
-                Requests, reliability and App Service capacity, read directly from
-                Azure Monitor. Samples refresh every 30 seconds.
-              </p>
             </div>
-
-            <div className={`border-2 p-4 ${healthClasses}`}>
-              <div className="flex items-start gap-3">
-                <Waves className="mt-0.5 size-5 shrink-0" aria-hidden />
-                <div>
-                  <span className="font-mono text-[11px] font-bold uppercase tracking-wide text-black/55 dark:text-[#D5D5D5]/55">
-                    System condition
-                  </span>
-                  <strong className="mt-1 block text-lg">
-                    {data?.health.label ?? "Establishing signal"}
-                  </strong>
-                  <p className="mt-1 text-xs leading-5 text-black/60 dark:text-[#D5D5D5]/60">
-                    {data?.health.reasons[0] ?? "Connecting to Azure Monitor"}
-                  </p>
-                </div>
-              </div>
+            <div className="flex items-center gap-2 text-sm">
+              <span className={`size-2 shrink-0 ${healthDotClass}`} />
+              <strong>{data?.health.label ?? "Connecting"}</strong>
             </div>
           </div>
 
-          <div className="mt-8 grid grid-cols-2 gap-3 sm:flex sm:flex-wrap sm:items-baseline sm:gap-x-6 sm:gap-y-2">
-            <InlineStat
-              label="RPM now"
-              value={formatCompact(summary?.currentRpm ?? 0)}
-              loading={loading}
-            />
-            <InlineStat
-              label="requests"
-              value={formatCompact(summary?.totalRequests ?? 0)}
-              loading={loading}
-            />
-            <InlineStat
-              label="availability"
-              value={`${formatDecimal(summary?.successRatePercent ?? 0, 2)}%`}
-              loading={loading}
-            />
-            <InlineStat
-              label="avg CPU"
-              value={`${formatDecimal(summary?.averageCpuPercent ?? 0, 1)}%`}
-              loading={loading}
-            />
-          </div>
-        </header>
-
-        <section className="flex flex-col gap-4">
-          <div className="flex flex-col justify-between gap-3 border-y-2 border-black/20 py-3 dark:border-white/20 sm:flex-row sm:items-center">
+          <div className="mt-5 flex flex-col justify-between gap-3 border-t border-black/15 pt-4 dark:border-white/15 sm:flex-row sm:items-center">
             <div className="flex flex-wrap gap-2" aria-label="Metric time range">
               {AZURE_MONITOR_RANGES.map((candidate) => (
                 <button
@@ -524,16 +477,15 @@ export default function AzureObservabilityDashboard({
               <Clock3 className="size-4" aria-hidden />
               {data
                 ? `Updated ${formatTime(data.fetchedAt)} · ${formatAge(data.latestMetricAt)}`
-                : `Loading ${RANGE_RESOLUTION[range]} samples`}
+                : `Loading ${RANGE_RESOLUTION[range]} data`}
             </div>
           </div>
           {error ? (
-            <div className="border-2 border-red-500 bg-red-500/10 p-4 text-sm" role="alert">
-              <strong>Azure Monitor is temporarily unavailable.</strong>{" "}
-              <span>{error}. This page will retry automatically.</span>
+            <div className="mt-4 border-l-2 border-red-500 pl-3 text-sm" role="alert">
+              <strong>Azure Monitor unavailable.</strong> <span>{error}</span>
             </div>
           ) : null}
-        </section>
+        </header>
 
         <section className="flex flex-col gap-4">
           <SectionHeading title="Traffic" detail={`${RANGE_RESOLUTION[range]} resolution`} />
@@ -541,38 +493,42 @@ export default function AzureObservabilityDashboard({
             <MetricCard
               label="Current RPM"
               value={formatCompact(summary?.currentRpm ?? 0)}
-              detail="Requests in the latest normalized minute"
+              detail="Latest sample"
               icon={Activity}
               loading={loading}
             />
             <MetricCard
               label="Average RPM"
               value={formatCompact(summary?.averageRpm ?? 0)}
-              detail={`Average across ${RANGE_LABELS[range]}`}
+              detail={`${RANGE_LABELS[range]} average`}
               loading={loading}
             />
             <MetricCard
               label="Peak RPM"
               value={formatCompact(summary?.peakRpm ?? 0)}
-              detail="Highest interval-normalized minute"
+              detail={`${RANGE_LABELS[range]} peak`}
               loading={loading}
             />
             <MetricCard
               label="Current RPS"
               value={formatDecimal(summary?.currentRps ?? 0, 2)}
-              detail={`Average ${formatDecimal(summary?.averageRps ?? 0, 2)} RPS`}
+              detail="Latest sample"
               loading={loading}
             />
             <MetricCard
               label="Total requests"
-              value={formatCompact(summary?.totalRequests ?? 0)}
-              detail={`Observed over ${RANGE_LABELS[range]}`}
+              value={formatCount(summary?.totalRequests ?? 0)}
+              detail={`${RANGE_LABELS[range]} total`}
               loading={loading}
             />
             <MetricCard
-              label="Daily run rate"
-              value={formatCompact(projectedDailyRequests)}
-              detail="Projected from this range average"
+              label="Burst factor"
+              value={`${formatDecimal(
+                (summary?.peakRpm ?? 0) /
+                  Math.max(summary?.averageRpm ?? 0, 0.01),
+                1,
+              )}×`}
+              detail="Peak / average RPM"
               loading={loading}
             />
           </div>
@@ -592,7 +548,7 @@ export default function AzureObservabilityDashboard({
             <MetricCard
               label="Server availability"
               value={`${formatDecimal(summary?.successRatePercent ?? 0, 2)}%`}
-              detail={`${formatCompact(summary?.successfulRequests ?? 0)} HTTP 2xx responses`}
+              detail={`${formatCount(summary?.successfulRequests ?? 0)} HTTP 2xx`}
               icon={ShieldCheck}
               loading={loading}
             />
@@ -617,14 +573,14 @@ export default function AzureObservabilityDashboard({
             <MetricCard
               label="Average response"
               value={formatLatency(summary?.averageResponseTimeMs ?? 0)}
-              detail="Azure backend response time"
+              detail="Mean backend time"
               icon={TimerReset}
               loading={loading}
             />
             <MetricCard
               label="Peak response"
               value={formatLatency(summary?.peakResponseTimeMs ?? 0)}
-              detail="Slowest interval maximum"
+              detail="Interval maximum"
               loading={loading}
             />
           </div>
@@ -712,39 +668,89 @@ export default function AzureObservabilityDashboard({
               </div>
             </aside>
           </div>
-          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        </section>
+
+        <section className="flex flex-col gap-4">
+          <SectionHeading title="Runtime & storage" detail="App Service metrics" />
+          <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
             <MetricCard
-              label="Peak CPU"
-              value={`${formatDecimal(summary?.peakCpuPercent ?? 0, 1)}%`}
-              detail={`${formatDecimal(100 - (summary?.averageCpuPercent ?? 0), 1)}% average headroom`}
+              label="CPU time"
+              value={formatDuration(summary?.totalCpuTimeSeconds ?? 0)}
+              detail={`${RANGE_LABELS[range]} total`}
               icon={Cpu}
               loading={loading}
             />
             <MetricCard
-              label="Peak memory"
-              value={`${formatDecimal(summary?.peakMemoryPercent ?? 0, 1)}%`}
-              detail={`${formatDecimal(100 - (summary?.averageMemoryPercent ?? 0), 1)}% average headroom`}
+              label="CPU / request"
+              value={`${formatDecimal(summary?.cpuTimePerRequestMs ?? 0, 2)} ms`}
+              detail="Mean per request"
+              loading={loading}
+            />
+            <MetricCard
+              label="File system"
+              value={`${formatDecimal(summary?.fileSystemUsageGiB ?? 0, 2)} GiB`}
+              detail="Latest 6-hour sample"
               icon={HardDrive}
               loading={loading}
             />
             <MetricCard
-              label="Data received"
-              value={`${formatDecimal(summary?.bytesReceivedGiB ?? 0, 2)} GiB`}
-              detail={`Across ${RANGE_LABELS[range]}`}
+              label="File system peak"
+              value={`${formatDecimal(summary?.peakFileSystemUsageGiB ?? 0, 2)} GiB`}
+              detail="Last 7 days"
               loading={loading}
             />
             <MetricCard
-              label="Data sent"
-              value={`${formatDecimal(summary?.bytesSentGiB ?? 0, 2)} GiB`}
-              detail={`Across ${RANGE_LABELS[range]}`}
+              label="Read throughput"
+              value={`${formatDecimal(summary?.currentIoReadMiBPerSecond ?? 0, 2)} MiB/s`}
+              detail="Latest sample"
               loading={loading}
+            />
+            <MetricCard
+              label="Peak read"
+              value={`${formatDecimal(summary?.peakIoReadMiBPerSecond ?? 0, 2)} MiB/s`}
+              detail={`${RANGE_LABELS[range]} peak`}
+              loading={loading}
+            />
+            <MetricCard
+              label="Write throughput"
+              value={`${formatDecimal(summary?.currentIoWriteKiBPerSecond ?? 0, 2)} KiB/s`}
+              detail={`${formatDecimal(summary?.peakIoWriteKiBPerSecond ?? 0, 2)} KiB/s peak`}
+              loading={loading}
+            />
+            <MetricCard
+              label="Disk queue"
+              value={formatDecimal(summary?.currentDiskQueueLength ?? 0, 0)}
+              detail={`${formatDecimal(summary?.maxDiskQueueLength ?? 0, 0)} peak`}
+              loading={loading}
+            />
+          </div>
+          <div className="grid gap-3 lg:grid-cols-2">
+            <MetricChart
+              title="Data transfer"
+              range={range}
+              series={data?.series ?? []}
+              lines={[
+                { key: "bytesReceivedMiB", label: "Received per interval", color: "#253EE0" },
+                { key: "bytesSentMiB", label: "Sent per interval", color: "#00A7D8" },
+              ]}
+              value={`${formatDecimal(summary?.bytesSentGiB ?? 0, 2)} GiB sent`}
+              empty={loading}
+            />
+            <MetricChart
+              title="Memory working set"
+              range={range}
+              series={data?.series ?? []}
+              lines={[
+                { key: "workingSetGiB", label: "Working set", color: "#F59E0B" },
+              ]}
+              value={`${formatDecimal(summary?.averageWorkingSetGiB ?? 0, 2)} GiB`}
+              empty={loading}
             />
           </div>
         </section>
 
         <footer className="border-t-2 border-black/20 pt-5 text-xs leading-5 text-black/50 dark:border-white/20 dark:text-[#D5D5D5]/50">
-          Azure Monitor platform metrics usually arrive one to three minutes late.
-          “Live” means the newest published platform sample, not request-level tracing.
+          Azure Monitor delay is usually 1–3 minutes.
         </footer>
       </div>
     </div>

--- a/lib/azure-monitor-types.ts
+++ b/lib/azure-monitor-types.ts
@@ -17,6 +17,10 @@ export type AzureMonitorPoint = {
   workingSetGiB: number | null;
   bytesReceivedMiB: number | null;
   bytesSentMiB: number | null;
+  cpuTimeSeconds: number | null;
+  ioReadMiBPerSecond: number | null;
+  ioWriteKiBPerSecond: number | null;
+  diskQueueLength: number | null;
 };
 
 export type AzureMonitorSnapshot = {
@@ -60,6 +64,16 @@ export type AzureMonitorSnapshot = {
     peakWorkingSetGiB: number;
     bytesReceivedGiB: number;
     bytesSentGiB: number;
+    totalCpuTimeSeconds: number;
+    cpuTimePerRequestMs: number;
+    currentIoReadMiBPerSecond: number;
+    peakIoReadMiBPerSecond: number;
+    currentIoWriteKiBPerSecond: number;
+    peakIoWriteKiBPerSecond: number;
+    fileSystemUsageGiB: number;
+    peakFileSystemUsageGiB: number;
+    currentDiskQueueLength: number;
+    maxDiskQueueLength: number;
     currentRps: number;
     currentRpm: number;
     currentCpuPercent: number;

--- a/lib/azure-monitor.ts
+++ b/lib/azure-monitor.ts
@@ -261,7 +261,7 @@ export async function getAzureMonitorSnapshot(
   const token = await getCredential().getToken(ARM_SCOPE);
   if (!token?.token) throw new Error("Azure identity did not return an access token");
 
-  const [appMetrics, planMetrics] = await Promise.all([
+  const [appMetrics, planMetrics, fileSystemMetrics] = await Promise.all([
     fetchAzureMetrics({
       accessToken: token.token,
       aggregation: "Total,Average,Maximum",
@@ -277,6 +277,9 @@ export async function getAzureMonitorSnapshot(
         "MemoryWorkingSet",
         "BytesReceived",
         "BytesSent",
+        "CpuTime",
+        "IoReadBytesPerSecond",
+        "IoWriteBytesPerSecond",
       ],
       resourceId: config.appResourceId,
       start,
@@ -286,9 +289,23 @@ export async function getAzureMonitorSnapshot(
       aggregation: "Average,Maximum",
       end,
       interval: rangeConfig.interval,
-      metricNames: ["CpuPercentage", "MemoryPercentage", "HttpQueueLength"],
+      metricNames: [
+        "CpuPercentage",
+        "MemoryPercentage",
+        "HttpQueueLength",
+        "DiskQueueLength",
+      ],
       resourceId: config.planResourceId,
       start,
+    }),
+    fetchAzureMetrics({
+      accessToken: token.token,
+      aggregation: "Average,Maximum",
+      end,
+      interval: "PT6H",
+      metricNames: ["FileSystemUsage"],
+      resourceId: config.appResourceId,
+      start: new Date(end.getTime() - 7 * 24 * 60 * 60 * 1_000),
     }),
   ]);
 
@@ -303,12 +320,41 @@ export async function getAzureMonitorSnapshot(
   const workingSetPeaks = metricValues(appMetrics, "MemoryWorkingSet", "maximum");
   const bytesReceived = metricValues(appMetrics, "BytesReceived", "total");
   const bytesSent = metricValues(appMetrics, "BytesSent", "total");
+  const cpuTime = metricValues(appMetrics, "CpuTime", "total");
+  const ioRead = metricValues(appMetrics, "IoReadBytesPerSecond", "average");
+  const ioReadPeaks = metricValues(
+    appMetrics,
+    "IoReadBytesPerSecond",
+    "maximum",
+  );
+  const ioWrite = metricValues(appMetrics, "IoWriteBytesPerSecond", "average");
+  const ioWritePeaks = metricValues(
+    appMetrics,
+    "IoWriteBytesPerSecond",
+    "maximum",
+  );
   const cpu = metricValues(planMetrics, "CpuPercentage", "average");
   const cpuPeaks = metricValues(planMetrics, "CpuPercentage", "maximum");
   const memory = metricValues(planMetrics, "MemoryPercentage", "average");
   const memoryPeaks = metricValues(planMetrics, "MemoryPercentage", "maximum");
   const queue = metricValues(planMetrics, "HttpQueueLength", "average");
   const queuePeaks = metricValues(planMetrics, "HttpQueueLength", "maximum");
+  const diskQueue = metricValues(planMetrics, "DiskQueueLength", "average");
+  const diskQueuePeaks = metricValues(
+    planMetrics,
+    "DiskQueueLength",
+    "maximum",
+  );
+  const fileSystemUsage = metricValues(
+    fileSystemMetrics,
+    "FileSystemUsage",
+    "average",
+  );
+  const fileSystemUsagePeaks = metricValues(
+    fileSystemMetrics,
+    "FileSystemUsage",
+    "maximum",
+  );
 
   const timestamps = Array.from(
     new Set([
@@ -319,6 +365,9 @@ export async function getAzureMonitorSnapshot(
       ...cpu.keys(),
       ...memory.keys(),
       ...responseTimes.keys(),
+      ...cpuTime.keys(),
+      ...ioRead.keys(),
+      ...ioWrite.keys(),
     ]),
   ).sort();
 
@@ -363,12 +412,23 @@ export async function getAzureMonitorSnapshot(
         bytesSent.has(timestamp)
           ? (bytesSent.get(timestamp) ?? 0) / 1_048_576
           : null,
+      cpuTimeSeconds: cpuTime.get(timestamp) ?? null,
+      ioReadMiBPerSecond:
+        ioRead.has(timestamp)
+          ? (ioRead.get(timestamp) ?? 0) / 1_048_576
+          : null,
+      ioWriteKiBPerSecond:
+        ioWrite.has(timestamp)
+          ? (ioWrite.get(timestamp) ?? 0) / 1_024
+          : null,
+      diskQueueLength: diskQueue.get(timestamp) ?? null,
     };
   });
 
   const totalRequests = total(series.map((point) => point.requests));
   const totalServerErrors = total(series.map((point) => point.serverErrors));
   const totalClientErrors = total(series.map((point) => point.clientErrors));
+  const totalCpuTimeSeconds = total(Array.from(cpuTime.values()));
   const elapsedSeconds = rangeConfig.durationMs / 1_000;
   const summary: AzureMonitorSnapshot["summary"] = {
     totalRequests: round(totalRequests, 0),
@@ -426,6 +486,42 @@ export async function getAzureMonitorSnapshot(
       total(Array.from(bytesSent.values())) / 1_073_741_824,
       2,
     ),
+    totalCpuTimeSeconds: round(totalCpuTimeSeconds, 1),
+    cpuTimePerRequestMs: round(
+      totalRequests > 0
+        ? (totalCpuTimeSeconds / totalRequests) * 1_000
+        : 0,
+      2,
+    ),
+    currentIoReadMiBPerSecond: round(
+      lastValue(Array.from(ioRead.values())) / 1_048_576,
+      2,
+    ),
+    peakIoReadMiBPerSecond: round(
+      maximum(Array.from(ioReadPeaks.values())) / 1_048_576,
+      2,
+    ),
+    currentIoWriteKiBPerSecond: round(
+      lastValue(Array.from(ioWrite.values())) / 1_024,
+      2,
+    ),
+    peakIoWriteKiBPerSecond: round(
+      maximum(Array.from(ioWritePeaks.values())) / 1_024,
+      2,
+    ),
+    fileSystemUsageGiB: round(
+      lastValue(Array.from(fileSystemUsage.values())) / 1_073_741_824,
+      2,
+    ),
+    peakFileSystemUsageGiB: round(
+      maximum(Array.from(fileSystemUsagePeaks.values())) / 1_073_741_824,
+      2,
+    ),
+    currentDiskQueueLength: round(
+      lastValue(Array.from(diskQueue.values())),
+      1,
+    ),
+    maxDiskQueueLength: round(maximum(Array.from(diskQueuePeaks.values())), 1),
     currentRps: round(lastValue(series.map((point) => point.rps)), 2),
     currentRpm: round(lastValue(series.map((point) => point.rpm)), 1),
     currentCpuPercent: round(


### PR DESCRIPTION
## Summary
- compress the observability header and remove redundant explanatory copy
- display large request totals using K/M notation and replace the duplicate daily projection with burst factor
- add CPU time, CPU per request, filesystem usage, disk queue, I/O throughput, transfer history, and working-set history
- only expose Azure metrics that return meaningful data for the production App Service

## Verification
- `pnpm exec tsc --noEmit`
- `pnpm build`
- authenticated desktop and mobile browser QA
- verified expanded metrics for 1h, 24h, 7d, and 30d against production Azure resources

<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

The moderator Azure observability dashboard adds CPU, filesystem, storage queue, I/O, transfer, and working-set telemetry with more compact summaries and charts.

Two reliability problems remain. A failure of the auxiliary filesystem metric prevents otherwise available Azure metrics from reaching the dashboard, and completed responses with no transfer or working-set samples are displayed as zero usage rather than unavailable telemetry.

## T-Rex validation blocked

Tool: the artifact-upload mechanism was unavailable. Focused reproductions completed, but their authored harnesses and captured outputs could not be attached as uploaded evidence.

<h3>Confidence Score: 3/5</h3>

Not safe to merge until the dashboard can tolerate an auxiliary Azure metric failure and accurately represent unavailable telemetry.

Two independent reliability failures were reproduced in focused checks: one turns a partial Azure Monitor outage into a complete dashboard outage, and the other converts absent telemetry into a measured zero value.

**Files Needing Attention:** `lib/azure-monitor.ts` needs independent failure handling for the filesystem request; `app/(mod)/mod/observability/azure-observability-dashboard.tsx` needs chart-specific missing-data detection.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex attempted end-to-end validation but the artifact-upload tool was unavailable, blocking full validation; focused reproductions were completed for a filesystem-only Azure Monitor failure and for snapshots containing no transfer or working-set samples.
- T-Rex produced proof for a posted P1 finding, with details available in the corresponding review comment.
- T-Rex documented that the Greptile artifact upload mechanism is unavailable in this run, so no upload IDs could be issued, and raw local artifact references are provided below.

<a href="https://app.greptile.com/trex/runs/17877981/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Empty Azure telemetry is presented as measured zero**

   - **Bug**
     - With a completed same-range snapshot containing no finite Data transfer or Memory working set datapoints, both charts receive `empty=false`, render chart paths, and display `0.00 GiB sent` / `0.00 GiB` rather than unavailable telemetry.
   - **Cause**
     - At `app/(mod)/mod/observability/azure-observability-dashboard.tsx:728-747`, both charts pass `empty={loading}`. Once the valid snapshot resolves, `loading` is false even when the relevant metric fields contain no numeric values.
   - **Fix**
     - Derive each chart’s empty state from loading or the absence of finite datapoints for that chart’s metric keys; retain the unavailable marker instead of rendering zero summaries.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22acm-vit%2Fexamcooker%22%20on%20the%20existing%20branch%20%22dev%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22dev%22.%0A%0A%23%23%23%20Issue%201%0Alib%2Fazure-monitor.ts%3A264-310%0A**Filesystem%20request%20breaks%20dashboard**%0A%0A%60FileSystemUsage%60%20is%20awaited%20in%20the%20same%20%60Promise.all%60%20as%20the%20core%20application%20and%20plan%20metrics.%20A%20failure%20limited%20to%20that%20auxiliary%20request%20rejects%20the%20whole%20snapshot%3B%20the%20Azure%20metrics%20endpoint%20then%20returns%20502%20rather%20than%20serving%20the%20otherwise%20successful%20telemetry.%20Isolate%20this%20request%20or%20degrade%20its%20filesystem%20fields%20when%20it%20fails.%0A%0A%23%23%23%20Issue%202%0Aapp%2F%28mod%29%2Fmod%2Fobservability%2Fazure-observability-dashboard.tsx%3A737-747%0A**Missing%20telemetry%20becomes%20zero**%0A%0ABoth%20charts%20use%20only%20%60loading%60%20to%20decide%20whether%20they%20are%20empty.%20Once%20a%20valid%20response%20finishes%20loading%2C%20a%20series%20containing%20no%20finite%20transfer%20or%20working-set%20values%20renders%20as%20populated%20and%20its%20summary%20is%20formatted%20as%20%600.00%20GiB%60.%20Derive%20each%20chart's%20empty%20state%20from%20the%20presence%20of%20numeric%20values%20for%20its%20own%20metric%20keys%20so%20unavailable%20telemetry%20is%20not%20presented%20as%20measured%20zero.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=acm-vit%2Fexamcooker&pr=527&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Alib%2Fazure-monitor.ts%3A264-310%0A**Filesystem%20request%20breaks%20dashboard**%0A%0A%60FileSystemUsage%60%20is%20awaited%20in%20the%20same%20%60Promise.all%60%20as%20the%20core%20application%20and%20plan%20metrics.%20A%20failure%20limited%20to%20that%20auxiliary%20request%20rejects%20the%20whole%20snapshot%3B%20the%20Azure%20metrics%20endpoint%20then%20returns%20502%20rather%20than%20serving%20the%20otherwise%20successful%20telemetry.%20Isolate%20this%20request%20or%20degrade%20its%20filesystem%20fields%20when%20it%20fails.%0A%0A%23%23%23%20Issue%202%0Aapp%2F%28mod%29%2Fmod%2Fobservability%2Fazure-observability-dashboard.tsx%3A737-747%0A**Missing%20telemetry%20becomes%20zero**%0A%0ABoth%20charts%20use%20only%20%60loading%60%20to%20decide%20whether%20they%20are%20empty.%20Once%20a%20valid%20response%20finishes%20loading%2C%20a%20series%20containing%20no%20finite%20transfer%20or%20working-set%20values%20renders%20as%20populated%20and%20its%20summary%20is%20formatted%20as%20%600.00%20GiB%60.%20Derive%20each%20chart's%20empty%20state%20from%20the%20presence%20of%20numeric%20values%20for%20its%20own%20metric%20keys%20so%20unavailable%20telemetry%20is%20not%20presented%20as%20measured%20zero.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=acm-vit%2Fexamcooker&pr=527&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Alib%2Fazure-monitor.ts%3A264-310%0A**Filesystem%20request%20breaks%20dashboard**%0A%0A%60FileSystemUsage%60%20is%20awaited%20in%20the%20same%20%60Promise.all%60%20as%20the%20core%20application%20and%20plan%20metrics.%20A%20failure%20limited%20to%20that%20auxiliary%20request%20rejects%20the%20whole%20snapshot%3B%20the%20Azure%20metrics%20endpoint%20then%20returns%20502%20rather%20than%20serving%20the%20otherwise%20successful%20telemetry.%20Isolate%20this%20request%20or%20degrade%20its%20filesystem%20fields%20when%20it%20fails.%0A%0A%23%23%23%20Issue%202%0Aapp%2F%28mod%29%2Fmod%2Fobservability%2Fazure-observability-dashboard.tsx%3A737-747%0A**Missing%20telemetry%20becomes%20zero**%0A%0ABoth%20charts%20use%20only%20%60loading%60%20to%20decide%20whether%20they%20are%20empty.%20Once%20a%20valid%20response%20finishes%20loading%2C%20a%20series%20containing%20no%20finite%20transfer%20or%20working-set%20values%20renders%20as%20populated%20and%20its%20summary%20is%20formatted%20as%20%600.00%20GiB%60.%20Derive%20each%20chart's%20empty%20state%20from%20the%20presence%20of%20numeric%20values%20for%20its%20own%20metric%20keys%20so%20unavailable%20telemetry%20is%20not%20presented%20as%20measured%20zero.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=527&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat: expand Azure dashboard metrics"](https://github.com/acm-vit/examcooker/commit/4c419ea73450ac63b0a6d32a861a53f9a95a2bab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51334094)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->