### PR TITLE
fix: update upload fields to clarify optional metadata and improve va…

### DIFF
--- a/app/components/upload-file.tsx
+++ b/app/components/upload-file.tsx
@@ -235,7 +235,7 @@ function UploadTitleField({
             className="w-full border-2 border-dashed border-gray-300 p-2 text-sm font-bold text-black dark:bg-[#0C1222] dark:text-[#D5D5D5] sm:text-base"
             value={value}
             onChange={(event) => onChange(index, event.target.value)}
-            required
+            placeholder="Title (optional)"
         />
     );
 }
@@ -243,16 +243,22 @@ function UploadTitleField({
 function CourseField({
     courseId,
     courses,
+    required = true,
     updateField,
 }: {
     courseId: string | null;
     courses: CourseOption[];
+    required?: boolean;
     updateField: UploadFieldChange;
 }) {
     return (
         <div>
             <p className="mb-1 block text-xs font-semibold uppercase tracking-wider text-black/60 dark:text-[#D5D5D5]/60">
-                Course <span className="text-red-500">*</span>
+                Course{required ? (
+                    <span className="text-red-500"> *</span>
+                ) : (
+                    <span className="font-normal normal-case tracking-normal"> · optional</span>
+                )}
             </p>
             <CoursePicker
                 courses={courses}
@@ -284,13 +290,16 @@ function PastPaperMetadataFields({
 }) {
     return (
         <>
+            <p className="text-xs leading-5 text-black/55 dark:text-[#D5D5D5]/55">
+                Metadata is optional. Leave anything blank and the AI review will fill in what it can from the paper.
+            </p>
             <div className="grid grid-cols-2 gap-3">
                 <div>
                     <label
                         htmlFor={ids.examTypeId}
                         className="mb-1 block text-xs font-semibold uppercase tracking-wider text-black/60 dark:text-[#D5D5D5]/60"
                     >
-                        Exam type <span className="text-red-500">*</span>
+                        Exam type
                     </label>
                     <select
                         id={ids.examTypeId}
@@ -335,7 +344,7 @@ function PastPaperMetadataFields({
                         htmlFor={ids.yearId}
                         className="mb-1 block text-xs font-semibold uppercase tracking-wider text-black/60 dark:text-[#D5D5D5]/60"
                     >
-                        Year <span className="text-red-500">*</span>
+                        Year
                     </label>
                     <select
                         id={ids.yearId}
@@ -1006,7 +1015,7 @@ function useUploadFileController({ variant, courses }: UploadFileProps) {
                 return;
             }
 
-            if (courses?.length && !courseId) {
+            if (variant === "Notes" && courses?.length && !courseId) {
                 dispatch({
                     type: "patch",
                     payload: { error: "Please select a course." },
@@ -1014,29 +1023,15 @@ function useUploadFileController({ variant, courses }: UploadFileProps) {
                 return;
             }
 
-            if (variant === "Past Papers" && courses?.length) {
-                if (!examType) {
-                    dispatch({
-                        type: "patch",
-                        payload: { error: "Please select an exam type." },
-                    });
-                    return;
-                }
-                if (!year) {
-                    dispatch({
-                        type: "patch",
-                        payload: { error: "Please select a year." },
-                    });
-                    return;
-                }
-            }
-
             startTransition(async () => {
                 try {
                     const formDatas = files.map((file, index) => {
                         const formData = new FormData();
                         formData.append("file", file);
-                        formData.append("filetitle", fileTitles[index]);
+                        formData.append(
+                            "filetitle",
+                            fileTitles[index]?.trim() || stripExtension(file.name),
+                        );
                         return formData;
                     });
 
@@ -1205,6 +1200,7 @@ function UploadFile({ variant, courses }: UploadFileProps) {
                         <CourseField
                             courseId={courseId}
                             courses={courses}
+                            required={variant === "Notes"}
                             updateField={updateField}
                         />
                     ) : null}

--- a/app/components/upload-file.tsx
+++ b/app/components/upload-file.tsx
@@ -290,9 +290,6 @@ function PastPaperMetadataFields({
 }) {
     return (
         <>
-            <p className="text-xs leading-5 text-black/55 dark:text-[#D5D5D5]/55">
-                Metadata is optional. Leave anything blank and the AI review will fill in what it can from the paper.
-            </p>
             <div className="grid grid-cols-2 gap-3">
                 <div>
                     <label


### PR DESCRIPTION
…lidation for course selection

<!-- greptile_comment -->

spent a lot of water and tokens to review your slop

<h3>Greptile Summary</h3>

This change makes upload titles optional by deriving them from the filename and relaxes metadata requirements for Past Papers. Verification found that a Past Paper submitted without a course is saved without a course association, while normal discovery pages only return course-associated papers; the upload can therefore succeed but remain unavailable through course and exam browsing. Verification also found that a file named `.pdf` produces an empty fallback title and is rejected by the processing endpoint despite the title being presented as optional.

<h3>Confidence Score: 4/5</h3>

The change should not merge until course-less Past Paper uploads are prevented or made discoverable, and filename-derived titles are guaranteed to be non-empty.

Focused executable checks reproduced one upload-discovery failure and one narrow filename edge case. Both findings are supported by captured scripts and output, and neither has a security consequence.

**Files Needing Attention:** app/components/upload-file.tsx needs a course invariant for Past Papers and a non-empty title fallback; app/api/uploads/route.ts should enforce the course invariant server-side as well.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced proofs for two P1 findings and ran focused Past Paper orphan-path validation, collecting runtime evidence and related guards and diffs (past path runtime, parent revision upload guard, checked-out revision exact-path validation, PR #539 diff, and live database validation blocker).
- T-Rex posted proofs for a P2 finding and performed validation of normal and extension-only PDF title fallbacks, recording outcomes where normal PDFs yield non-empty titles and extension-only names trigger an empty title with HTTP 400.
- T-Rex performed general contract validation to confirm the scope of PR #539 and included the authored validation script and its outputs.
- T-Rex validated extension-only title logic by running the dedicated validation script and observing baseline non-empty titles for normal PDFs and empty titles with 400 for the extension-only case.

<a href="https://app.greptile.com/trex/runs/18069233/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Past Paper uploads without a course persist as orphaned records**

   - **Bug**
     - `app/components/upload-file.tsx:1015` only enforces a course for Notes. A Past Papers submission with courses available may continue with an empty `courseId`; `app/api/uploads/route.ts:160` normalizes that to null and `lib/uploads/create-uploaded-resources.ts:127` omits the field, so the nullable schema column stores null. Course listing, exam hub, and promotion discovery filters require an assigned course.
   - **Cause**
     - The client and server do not require `courseId` for the Past Papers variant although its consumer queries are course-bound.
   - **Fix**
     - Require a course for Past Papers in the submit handler and enforce the same invariant in `POST /api/uploads` before consuming receipts/persisting. Consider repairing existing null-course PastPaper rows through moderation or a backfill.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>


2. General comment 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Extension-only PDF filenames submit an empty title and are rejected**

   - **Bug**
     - At `app/components/upload-file.tsx:1028-1031`, the empty manual-title fallback calls `stripExtension(file.name)`. The current regex converts `.pdf` to an empty string. The request then sends `filetitle=""`; at `app/api/uploads/process/route.ts:39-44`, `title` remains empty and the exact `!(file instanceof File) || !title` guard returns HTTP 400 with `A PDF and title are required.`
   - **Cause**
     - `stripExtension(filename)` removes the entire extension-only filename, while the submit path has no non-empty fallback after stripping.
   - **Fix**
     - Ensure the fallback is non-empty before appending `filetitle`, for example use a stable default such as `stripExtension(file.name) || "Untitled PDF"`; alternatively reject extension-only filenames client-side with a clear title prompt.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22acm-vit%2Fexamcooker%22%20on%20the%20existing%20branch%20%22dev%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22dev%22.%0A%0A%23%23%23%20Issue%201%0Aapp%2Fcomponents%2Fupload-file.tsx%3A1015%0A**Course-less%20Past%20Papers%20become%20orphaned**%0A%0AThis%20guard%20permits%20a%20Past%20Paper%20to%20continue%20without%20a%20selected%20course.%20The%20request%20is%20then%20persisted%20with%20a%20null%20%60courseId%60%2C%20but%20course%20listings%2C%20the%20exam%20hub%2C%20and%20promotion%20queries%20only%20return%20papers%20with%20an%20assigned%20course.%20The%20upload%20succeeds%20while%20remaining%20unavailable%20through%20the%20product's%20normal%20discovery%20paths.%20Require%20a%20course%20for%20Past%20Papers%20in%20the%20client%20flow%20and%20enforce%20the%20same%20invariant%20in%20the%20upload%20API%20before%20persistence.%0A%0A%23%23%23%20Issue%202%0Aapp%2Fcomponents%2Fupload-file.tsx%3A1028-1031%0A**Extension-only%20filenames%20yield%20an%20empty%20title**%0A%0AWhen%20the%20optional%20title%20is%20blank%2C%20%60.pdf%60%20is%20passed%20through%20%60stripExtension%60%20and%20becomes%20an%20empty%20string.%20The%20processing%20request%20therefore%20sends%20an%20empty%20%60filetitle%60%2C%20and%20the%20processing%20endpoint%20rejects%20it%20with%20HTTP%20400%20and%20%E2%80%9CA%20PDF%20and%20title%20are%20required.%E2%80%9D%20Use%20a%20stable%20non-empty%20fallback%20when%20the%20stripped%20filename%20is%20empty%2C%20or%20require%20an%20entered%20title%20for%20this%20filename%20shape.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=acm-vit%2Fexamcooker&pr=539&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aapp%2Fcomponents%2Fupload-file.tsx%3A1015%0A**Course-less%20Past%20Papers%20become%20orphaned**%0A%0AThis%20guard%20permits%20a%20Past%20Paper%20to%20continue%20without%20a%20selected%20course.%20The%20request%20is%20then%20persisted%20with%20a%20null%20%60courseId%60%2C%20but%20course%20listings%2C%20the%20exam%20hub%2C%20and%20promotion%20queries%20only%20return%20papers%20with%20an%20assigned%20course.%20The%20upload%20succeeds%20while%20remaining%20unavailable%20through%20the%20product's%20normal%20discovery%20paths.%20Require%20a%20course%20for%20Past%20Papers%20in%20the%20client%20flow%20and%20enforce%20the%20same%20invariant%20in%20the%20upload%20API%20before%20persistence.%0A%0A%23%23%23%20Issue%202%0Aapp%2Fcomponents%2Fupload-file.tsx%3A1028-1031%0A**Extension-only%20filenames%20yield%20an%20empty%20title**%0A%0AWhen%20the%20optional%20title%20is%20blank%2C%20%60.pdf%60%20is%20passed%20through%20%60stripExtension%60%20and%20becomes%20an%20empty%20string.%20The%20processing%20request%20therefore%20sends%20an%20empty%20%60filetitle%60%2C%20and%20the%20processing%20endpoint%20rejects%20it%20with%20HTTP%20400%20and%20%E2%80%9CA%20PDF%20and%20title%20are%20required.%E2%80%9D%20Use%20a%20stable%20non-empty%20fallback%20when%20the%20stripped%20filename%20is%20empty%2C%20or%20require%20an%20entered%20title%20for%20this%20filename%20shape.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=acm-vit%2Fexamcooker&pr=539&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Aapp%2Fcomponents%2Fupload-file.tsx%3A1015%0A**Course-less%20Past%20Papers%20become%20orphaned**%0A%0AThis%20guard%20permits%20a%20Past%20Paper%20to%20continue%20without%20a%20selected%20course.%20The%20request%20is%20then%20persisted%20with%20a%20null%20%60courseId%60%2C%20but%20course%20listings%2C%20the%20exam%20hub%2C%20and%20promotion%20queries%20only%20return%20papers%20with%20an%20assigned%20course.%20The%20upload%20succeeds%20while%20remaining%20unavailable%20through%20the%20product's%20normal%20discovery%20paths.%20Require%20a%20course%20for%20Past%20Papers%20in%20the%20client%20flow%20and%20enforce%20the%20same%20invariant%20in%20the%20upload%20API%20before%20persistence.%0A%0A%23%23%23%20Issue%202%0Aapp%2Fcomponents%2Fupload-file.tsx%3A1028-1031%0A**Extension-only%20filenames%20yield%20an%20empty%20title**%0A%0AWhen%20the%20optional%20title%20is%20blank%2C%20%60.pdf%60%20is%20passed%20through%20%60stripExtension%60%20and%20becomes%20an%20empty%20string.%20The%20processing%20request%20therefore%20sends%20an%20empty%20%60filetitle%60%2C%20and%20the%20processing%20endpoint%20rejects%20it%20with%20HTTP%20400%20and%20%E2%80%9CA%20PDF%20and%20title%20are%20required.%E2%80%9D%20Use%20a%20stable%20non-empty%20fallback%20when%20the%20stripped%20filename%20is%20empty%2C%20or%20require%20an%20entered%20title%20for%20this%20filename%20shape.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=539&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Update upload-file.tsx"](https://github.com/acm-vit/examcooker/commit/f67a324f1248334e21786a1adf53a5e3a311d9e4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51723794)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->